### PR TITLE
Added symlink to DVDongle in order to prevent overwriting of config

### DIFF
--- a/Digital Voice/Common/SerialController.cpp
+++ b/Digital Voice/Common/SerialController.cpp
@@ -111,6 +111,7 @@ wxArrayString CSerialController::getDevices()
 	devices.Add(wxT("/dev/ttyUSB2"));
 	devices.Add(wxT("/dev/ttyUSB3"));
 	devices.Add(wxT("/dev/ttyUSB4"));
+	devices.Add(wxT("/dev/DVDongle"));
 #endif
 
 	return devices;

--- a/Digital Voice/Common/SerialDataController.cpp
+++ b/Digital Voice/Common/SerialDataController.cpp
@@ -65,6 +65,7 @@ wxArrayString CSerialDataController::getDevices()
 	devices.Add(wxT("/dev/ttyUSB2"));
 	devices.Add(wxT("/dev/ttyUSB3"));
 	devices.Add(wxT("/dev/ttyUSB4"));
+	devices.Add(wxT("/dev/DVDongle"));
 #endif
 
 	return devices;


### PR DESCRIPTION
As I have multiple serial devices attached, the DVDongle apparently appears as different ttyUSBX device from time to time. Additionally it can be one of the devices with a number greater than 4. So I suggest adding a device with actually is a symlink to the DVDongle. I realize this with an udev rule that creates a symlink from /dev/DVDongle to the serial device it is attached to.
Editing the config of DCSClient for example results in overwriting because the device /dev/DVDongle is unknown.