### PR TITLE
bug fix: make a deep copy of the string to prevent problems in threads

### DIFF
--- a/ircDDBGateway/ircDDB/IRCDDBApp.cpp
+++ b/ircDDBGateway/ircDDB/IRCDDBApp.cpp
@@ -532,8 +532,10 @@ wxString IRCDDBApp::getIPAddress(wxString& zonerp_cs)
 
       if (o.usn >= max_usn)
       {
-	max_usn = o.usn;
-	ipAddr = o.host;
+		max_usn = o.usn;
+		ipAddr = o.host.c_str(); // make a deep copy of the string and do not use wxString reference counting!
+							// This is important, because the reference counting feature
+							// in wxString is not thread-safe.
       }
       // i = 1;
     }


### PR DESCRIPTION
The reference counting feature in wxString is not thread safe. This method "getIPAddress" returns the IP address as a wxString. The method is called from a different thread than the one which created the user list where the IP address is stored. Because the string is an identical copy, wxString uses reference counting. Sometimes, the wxString object is created in one thread and deleted in the other... I think this is where the memory corruption occurs.
Creating a deep copy of the string prevents the use of the same wxString object in two threads.

73s de Michael, DL1BFF