### PR TITLE
Update IRCDDBGatewayConfigFrame.cpp for window sizing

### DIFF
--- a/ircDDBGateway/ircDDBGatewayConfig/IRCDDBGatewayConfigFrame.cpp
+++ b/ircDDBGateway/ircDDBGatewayConfig/IRCDDBGatewayConfigFrame.cpp
@@ -20,7 +20,7 @@
 #include "IRCDDBGatewayConfigDefs.h"
 #include "Version.h"
 
-const unsigned int BORDER_SIZE = 5;
+const unsigned int BORDER_SIZE = 5U;
 
 #include <wx/gbsizer.h>
 #include <wx/aboutdlg.h>

--- a/ircDDBGateway/ircDDBGatewayConfig/IRCDDBGatewayConfigFrame.cpp
+++ b/ircDDBGateway/ircDDBGatewayConfig/IRCDDBGatewayConfigFrame.cpp
@@ -20,7 +20,7 @@
 #include "IRCDDBGatewayConfigDefs.h"
 #include "Version.h"
 
-const unsigned int BORDER_SIZE = 5U;
+const unsigned int BORDER_SIZE = 5;
 
 #include <wx/gbsizer.h>
 #include <wx/aboutdlg.h>
@@ -298,15 +298,15 @@ m_miscellaneous(NULL)
 	m_miscellaneous = new CIRCDDBGatewayConfigMiscellaneousSet(noteBook, -1, APPLICATION_NAME, language, infoEnabled, echoEnabled, logEnabled, dratsEnabled, dtmfEnabled);
 	noteBook->AddPage(m_miscellaneous, wxT("Misc"), false);
 
-	sizer->Add(noteBook, 1, wxALL | wxGROW, BORDER_SIZE);
+        sizer->Add(noteBook, 0, wxEXPAND | wxALL, BORDER_SIZE);
 
-	panel->SetSizer(sizer);
+        panel->SetSizer(sizer);
 
-	mainSizer->Add(panel);
+        mainSizer->Add(panel, 0, wxEXPAND | wxALL, BORDER_SIZE);
 
-	SetSizer(mainSizer);
+        mainSizer->SetSizeHints(this);
 
-	mainSizer->SetSizeHints(this);
+        SetSizer(mainSizer);
 }
 
 CIRCDDBGatewayConfigFrame::~CIRCDDBGatewayConfigFrame()


### PR DESCRIPTION
this is just to see if you like the behavior of a GUI change, I have always hated that the wxNoteBook wont resize with the window and your stuck with two tiny tabs - if this is tested and accepted by others on the team I will continue making changes to all config notebooks (product compiled and tested ok for me)