### PR TITLE
Fixed malformed APRS connect string when no filter is pecified.

### DIFF
--- a/ircDDBGateway/Common/APRSWriterThread.cpp
+++ b/ircDDBGateway/Common/APRSWriterThread.cpp
@@ -34,8 +34,8 @@ m_queue(20U),
 m_exit(false),
 m_connected(false),
 m_APRSReadCallback(NULL),
-m_filter(wxT("ircDDBGateway")),
-m_clientName()
+m_filter(wxT("")),
+m_clientName(wxT("ircDDBGateway"))
 {
 	wxASSERT(!callsign.IsEmpty());
 	wxASSERT(!hostname.IsEmpty());


### PR DESCRIPTION
Hi,

I think there was a small typo/confusion when removign my delegating constructors. This fixes this issue.

73
Geoffrey