### PR TITLE
This commit solves the issue https://github.com/dl5di/OpenDV/issues/47

### DIFF
--- a/ircDDBGateway/Common/DCSHandler.cpp
+++ b/ircDDBGateway/Common/DCSHandler.cpp
@@ -38,8 +38,8 @@ CCallsignList*           CDCSHandler::m_blackList = NULL;
 
 
 CDCSHandler::CDCSHandler(IReflectorCallback* handler, const wxString& reflector, const wxString& repeater, CDCSProtocolHandler* protoHandler, const in_addr& address, unsigned int port, DIRECTION direction) :
-m_reflector(reflector),
-m_repeater(repeater),
+m_reflector(reflector.Clone()),
+m_repeater(repeater.Clone()),
 m_handler(protoHandler),
 m_yourAddress(address),
 m_yourPort(port),

--- a/ircDDBGateway/Common/DExtraHandler.cpp
+++ b/ircDDBGateway/Common/DExtraHandler.cpp
@@ -38,8 +38,8 @@ CCallsignList*              CDExtraHandler::m_blackList = NULL;
 
 
 CDExtraHandler::CDExtraHandler(IReflectorCallback* handler, const wxString& reflector, const wxString& repeater, CDExtraProtocolHandler* protoHandler, const in_addr& address, unsigned int port, DIRECTION direction) :
-m_reflector(reflector),
-m_repeater(repeater),
+m_reflector(reflector.Clone()),
+m_repeater(repeater.Clone()),
 m_handler(protoHandler),
 m_yourAddress(address),
 m_yourPort(port),
@@ -75,7 +75,7 @@ m_header(NULL)
 }
 
 CDExtraHandler::CDExtraHandler(CDExtraProtocolHandler* protoHandler, const wxString& reflector, const in_addr& address, unsigned int port, DIRECTION direction) :
-m_reflector(reflector),
+m_reflector(reflector.Clone()),
 m_repeater(),
 m_handler(protoHandler),
 m_yourAddress(address),
@@ -131,7 +131,8 @@ void CDExtraHandler::initialise(unsigned int maxReflectors)
 
 void CDExtraHandler::setCallsign(const wxString& callsign)
 {
-	m_callsign = callsign;
+	m_callsign = callsign.Clone();//clone makes deep copy of string, this adds thread safety to our code !
+	m_callsign.resize(LONG_CALLSIGN_LENGTH, ' ');
 	m_callsign.SetChar(LONG_CALLSIGN_LENGTH - 1U, wxT(' '));
 }
 

--- a/ircDDBGateway/Common/DPlusHandler.cpp
+++ b/ircDDBGateway/Common/DPlusHandler.cpp
@@ -73,8 +73,7 @@ m_header(NULL)
 
 	m_time = ::time(NULL);
 
-	m_callsign.Append(wxT("                      "));
-	m_callsign.Truncate(LONG_CALLSIGN_LENGTH);
+	m_callsign.resize(LONG_CALLSIGN_LENGTH, ' ');
 	wxChar band = m_repeater.GetChar(LONG_CALLSIGN_LENGTH - 1U);
 	m_callsign.SetChar(LONG_CALLSIGN_LENGTH - 1U, band);
 }

--- a/ircDDBGateway/Common/DPlusHandler.cpp
+++ b/ircDDBGateway/Common/DPlusHandler.cpp
@@ -42,9 +42,9 @@ CCallsignList*             CDPlusHandler::m_blackList = NULL;
 
 
 CDPlusHandler::CDPlusHandler(IReflectorCallback* handler, const wxString& repeater, const wxString& reflector, CDPlusProtocolHandler* protoHandler, const in_addr& address, unsigned int port) :
-m_repeater(repeater),
-m_callsign(m_dplusLogin),
-m_reflector(reflector),
+m_repeater(repeater.Clone()),
+m_callsign(m_dplusLogin.Clone()),
+m_reflector(reflector.Clone()),
 m_handler(protoHandler),
 m_yourAddress(address),
 m_yourPort(port),
@@ -73,7 +73,9 @@ m_header(NULL)
 
 	m_time = ::time(NULL);
 
-	wxChar band = repeater.GetChar(LONG_CALLSIGN_LENGTH - 1U);
+	m_callsign.Append(wxT("                      "));
+	m_callsign.Truncate(LONG_CALLSIGN_LENGTH);
+	wxChar band = m_repeater.GetChar(LONG_CALLSIGN_LENGTH - 1U);
 	m_callsign.SetChar(LONG_CALLSIGN_LENGTH - 1U, band);
 }
 


### PR DESCRIPTION
It all starts in the DPlusHandler constructor wher eband char is added to m_callsign. If m_callssign is smaller than LONG_CALLSIGN_LENGTH the band char gets added "somewhere" (overrun ?)
SetChar does not complain about a char being set outside the string boundaries.
In the end when the DPlushandler gets deleted its internal members gets deleted also and we get an error from wxString destructor about freeing the wrong size.
What I did to solve the issue :
- Make use of wxString::Clone to set the members. This makes a deep copy of wxString, thus ensuring more thread safety.
- Add withespaces to m_callsign and then truncate it to correct length
- set the band char