### PR TITLE
Fix typo in Makefile and add cstring include to fix compilation

### DIFF
--- a/MMDVMHost/Makefile
+++ b/MMDVMHost/Makefile
@@ -27,7 +27,7 @@ CSBK.o:	CSBK.cpp CSBK.h Utils.h DMRDefines.h BPTC19696.h CRC.h Log.h
 Display.o:	Display.cpp Display.h
 		$(CC) $(CFLAGS) -c Display.cpp
 
-DMRControl.o:	DMRControl.cpp DMRControl.h DMRSlot.h DMRData.h Modem.h HomebrewDMRIPSC.h Defines.h CSBK.h Log.h DIsplay.h
+DMRControl.o:	DMRControl.cpp DMRControl.h DMRSlot.h DMRData.h Modem.h HomebrewDMRIPSC.h Defines.h CSBK.h Log.h Display.h
 		$(CC) $(CFLAGS) -c DMRControl.cpp
 
 DMRData.o:	DMRData.cpp DMRData.h DMRDefines.h Utils.h Log.h

--- a/MMDVMHost/TFTSerial.h
+++ b/MMDVMHost/TFTSerial.h
@@ -23,6 +23,7 @@
 #include "SerialController.h"
 
 #include <string>
+#include <cstring>
 
 class CTFTSerial : public IDisplay
 {


### PR DESCRIPTION
DIsplay.h is an obvious typo that needs to be fixed :)

On my Odroid Arch Linux I need to include cstring in TFTSerial.h otherwise it won't find std::strlen etc