### PR TITLE
Add URI device as a controller option in DStarRepeater

### DIFF
--- a/DStarRepeater/Common/Makefile
+++ b/DStarRepeater/Common/Makefile
@@ -5,7 +5,7 @@ OBJS :=	AMBEFEC.o AnnouncementUnit.o ArduinoController.o BeaconUnit.o CallsignLi
 		DVRPTRV3Controller.o DVTOOLFileReader.o DVTOOLFileWriter.o ExternalController.o FIRFilter.o GatewayProtocolHandler.o GMSKController.o GMSKModem.o \
 		GMSKModemLibUsb.o Golay.o GPIOController.o HardwareController.o HeaderData.o K8055Controller.o LogEvent.o Logger.o MMDVMController.o Modem.o OutputQueue.o \
 		RepeaterProtocolHandler.o SerialDataController.o SerialLineController.o SerialPortSelector.o SlowDataDecoder.o SlowDataEncoder.o SoundCardController.o \
-		SoundCardReaderWriter.o SplitController.o TCPReaderWriter.o Timer.o UDPReaderWriter.o Utils.o
+		SoundCardReaderWriter.o SplitController.o TCPReaderWriter.o Timer.o UDPReaderWriter.o URIUSBController.o Utils.o
 
 Common.a:	$(OBJS)
 		ar rcs Common.a $(OBJS)
@@ -153,6 +153,9 @@ Timer.o:	Timer.cpp Timer.h
 
 UDPReaderWriter.o:	UDPReaderWriter.cpp UDPReaderWriter.h Utils.h
 		$(CC) $(CFLAGS) -c UDPReaderWriter.cpp
+
+URIUSBController.o:	URIUSBController.cpp URIUSBController.h HardwareController.h
+		$(CC) $(CFLAGS) -c URIUSBController.cpp
 
 Utils.o:	Utils.cpp Utils.h
 		$(CC) $(CFLAGS) -c Utils.cpp

--- a/DStarRepeater/Common/URIUSBController.cpp
+++ b/DStarRepeater/Common/URIUSBController.cpp
@@ -1,0 +1,411 @@
+/*
+ *	Copyright (C) 2009-2013 by Jonathan Naylor, G4KLX
+ *
+ *	This program is free software; you can redistribute it and/or modify
+ *	it under the terms of the GNU General Public License as published by
+ *	the Free Software Foundation; version 2 of the License.
+ *
+ *	This program is distributed in the hope that it will be useful,
+ *	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *	GNU General Public License for more details.
+ */
+
+#include "URIUSBController.h"
+
+const unsigned int C108_VENDOR_ID     = 0x0D8CU;
+const unsigned int C108_PRODUCT_ID    = 0x000CU;
+const unsigned int C108AH_PRODUCT_ID  = 0x013CU;
+const unsigned int C119_PRODUCT_ID    = 0x0008U;
+const unsigned int C119A_PRODUCT_ID   = 0x013AU;
+
+const char REPORT_ID     = 0x00;
+
+const char HID_OR0       = 0x00;
+const char HID_OR1       = 0x00;
+const char HID_OR2       = 0x0F;	// Set GPIO1 to GPIO4 to output
+const char HID_OR3       = 0x00;
+const char HID_OR1_GPIO4 = 0x08;	// GPIO4, Switched
+const char HID_OR1_GPIO3 = 0x04;	// GPIO3, PTT
+const char HID_OR1_GPIO2 = 0x02;	// GPIO2, Switched
+const char HID_OR1_GPIO1 = 0x01;	// GPIO1, Heartbeat
+const char HID_IR0_RM    = 0x08;	// Record-Mute, Disable
+const char HID_IR0_PM    = 0x04;	// Playback-Mute, Battery
+const char HID_IR0_VD    = 0x02;	// Volume-Down, COR_DET
+const char HID_IR0_VU    = 0x01;	// Volume-Up, CTCSS_DET
+
+#if defined(__WINDOWS__)
+
+#include <Setupapi.h>
+#include "HID.h"
+
+const ULONG USB_BUFSIZE = 5UL;
+
+CURIUSBController::CURIUSBController(unsigned int address, bool checkInput) :
+m_address(address),
+m_checkInput(checkInput),
+m_outp1(false),
+m_outp3(false),
+m_outp5(false),
+m_outp6(false),
+m_handle(INVALID_HANDLE_VALUE)
+{
+}
+
+CURIUSBController::~CURIUSBController()
+{
+}
+
+bool CURIUSBController::open()
+{
+	wxASSERT(m_handle == INVALID_HANDLE_VALUE);
+
+	GUID guid;
+	::HidD_GetHidGuid(&guid);
+
+	HDEVINFO devInfo = ::SetupDiGetClassDevs(&guid, NULL, NULL, DIGCF_DEVICEINTERFACE | DIGCF_PRESENT);
+	if (devInfo == INVALID_HANDLE_VALUE) {
+		wxLogError(wxT("Error from SetupDiGetClassDevs: err=%u"), ::GetLastError());
+		return false;
+	}
+
+	SP_DEVICE_INTERFACE_DATA devInfoData;
+	devInfoData.cbSize = sizeof(SP_DEVICE_INTERFACE_DATA);
+
+	unsigned int count = 0U;
+	for (DWORD index = 0U; ::SetupDiEnumDeviceInterfaces(devInfo, NULL, &guid, index, &devInfoData); index++) {
+		// Find the required length of the device structure
+		DWORD length;
+		::SetupDiGetDeviceInterfaceDetail(devInfo, &devInfoData, NULL, 0U, &length, NULL);
+
+		PSP_DEVICE_INTERFACE_DETAIL_DATA detailData = PSP_DEVICE_INTERFACE_DETAIL_DATA(::malloc(length));
+		detailData->cbSize = sizeof(SP_DEVICE_INTERFACE_DETAIL_DATA);
+
+		// Get the detailed data into the newly allocated device structure
+		DWORD required;
+		BOOL res = ::SetupDiGetDeviceInterfaceDetail(devInfo, &devInfoData, detailData, length, &required, NULL);
+		if (!res) {
+			wxLogError(wxT("Error from SetupDiGetDeviceInterfaceDetail: err=%u"), ::GetLastError());
+			::SetupDiDestroyDeviceInfoList(devInfo);
+			::free(detailData);
+			return false;
+		}
+
+		// Get the handle for getting the attributes
+		HANDLE handle = ::CreateFile(detailData->DevicePath, 0, FILE_SHARE_READ | FILE_SHARE_WRITE, NULL, OPEN_EXISTING, 0, NULL);
+		if (handle == INVALID_HANDLE_VALUE) {
+			wxLogError(wxT("Error from CreateFile: err=%u"), ::GetLastError());
+			::SetupDiDestroyDeviceInfoList(devInfo);
+			::free(detailData);
+			return false;
+		}
+
+		HIDD_ATTRIBUTES attributes;
+		attributes.Size = sizeof(HIDD_ATTRIBUTES);
+		res = ::HidD_GetAttributes(handle, &attributes);
+		if (!res) {
+			wxLogError(wxT("Error from HidD_GetAttributes: err=%u"), ::GetLastError());
+			::CloseHandle(handle);
+			::SetupDiDestroyDeviceInfoList(devInfo);
+			::free(detailData);
+			return false;
+		}
+
+		::CloseHandle(handle);
+
+		// Is this a CM108 or equivalent?
+		if (attributes.VendorID  == C108_VENDOR_ID    &&
+		   (attributes.ProductID == C108_PRODUCT_ID   ||
+			attributes.ProductID == C108AH_PRODUCT_ID ||
+			attributes.ProductID == C119_PRODUCT_ID   ||
+			attributes.ProductID == C119A_PRODUCT_ID)) {
+				count++;
+
+			// Is this the right device?
+			if (count == m_address) {
+				m_handle = ::CreateFile(detailData->DevicePath, GENERIC_WRITE | GENERIC_READ, FILE_SHARE_READ | FILE_SHARE_WRITE, NULL, OPEN_EXISTING, 0, NULL);
+				if (m_handle == INVALID_HANDLE_VALUE) {
+					wxLogError(wxT("Error from CreateFile: err=%u"), ::GetLastError());
+					::SetupDiDestroyDeviceInfoList(devInfo);
+					::free(detailData);
+					return false;
+				}
+
+				::SetupDiDestroyDeviceInfoList(devInfo);
+				::free(detailData);
+
+				setDigitalOutputs(false, false, false, false, false, false, false, false);
+
+				return true;
+			}
+		}
+
+		::free(detailData);
+	}
+
+	::SetupDiDestroyDeviceInfoList(devInfo);
+
+	return false;
+}
+
+void CURIUSBController::getDigitalInputs(bool& inp1, bool& inp2, bool& inp3, bool& inp4, bool& inp5)
+{
+	wxASSERT(m_handle != INVALID_HANDLE_VALUE);
+
+	if (!m_checkInput) {
+		inp1 = inp2 = inp3 = inp4 = inp5 = false;
+		return;
+	}
+
+	char buffer[USB_BUFSIZE];
+	buffer[0] = REPORT_ID;
+	buffer[1] = 0x00;
+	buffer[2] = 0x00;
+	buffer[3] = 0x00;
+	buffer[4] = 0x00;
+	BOOL res = ::HidD_GetInputReport(m_handle, buffer, USB_BUFSIZE);
+	if (!res) {
+		wxLogError(wxT("Error from HidD_GetInputReport: err=%u"), ::GetLastError());
+		return;
+	}
+
+	inp3 = false;
+
+	inp5 = (buffer[1] & HID_IR0_RM) == HID_IR0_RM;	// Disable
+	inp4 = (buffer[1] & HID_IR0_PM) == HID_IR0_PM;	// Battery
+	inp2 = (buffer[1] & HID_IR0_VU) == HID_IR0_VU;	// Squelch 2
+	inp1 = (buffer[1] & HID_IR0_VD) == HID_IR0_VD;	// Squelch 1
+}
+
+void CURIUSBController::setDigitalOutputs(bool outp1, bool, bool outp3, bool outp4, bool outp5, bool outp6, bool, bool)
+{
+	wxASSERT(m_handle != INVALID_HANDLE_VALUE);
+
+	if (outp1 == m_outp1 && outp3 == m_outp3 && outp5 == m_outp5 && outp6 == m_outp6)
+		return;
+
+	char buffer[USB_BUFSIZE];
+	buffer[0] = REPORT_ID;
+	buffer[1] = HID_OR0;
+	buffer[2] = HID_OR1;
+	buffer[3] = HID_OR2;
+	buffer[4] = HID_OR3;
+
+	if (outp1)			// Transmit
+		buffer[2] |= HID_OR1_GPIO3;
+	if (outp3)			// Heartbeat
+		buffer[2] |= HID_OR1_GPIO1;
+	if (outp4)			// Active
+		buffer[2] |= HID_OR1_GPIO2;
+	if (outp5)			// Output 1
+		buffer[2] |= HID_OR1_GPIO4;
+
+	BOOL res = ::HidD_SetOutputReport(m_handle, buffer, USB_BUFSIZE);
+	if (!res)
+		wxLogError(wxT("Error from HidD_SetOutputReport: err=%u"), ::GetLastError());
+
+	m_outp1 = outp1;
+	m_outp3 = outp3;
+	m_outp5 = outp5;
+	m_outp6 = outp6;
+}
+
+void CURIUSBController::close()
+{
+	wxASSERT(m_handle != INVALID_HANDLE_VALUE);
+
+	setDigitalOutputs(false, false, false, false, false, false, false, false);
+
+	::CloseHandle(m_handle);
+	m_handle = INVALID_HANDLE_VALUE;
+}
+
+#else
+
+const unsigned int C108_HID_INTERFACE = 3U;
+
+const unsigned int HID_REPORT_GET = 0x01U;
+const unsigned int HID_REPORT_SET = 0x09U;
+
+const unsigned int HID_RT_INPUT   = 0x01U;
+const unsigned int HID_RT_OUTPUT  = 0x02U;
+
+const int USB_BUFSIZE = 4;
+
+const int USB_TIMEOUT = 5000;
+
+CURIUSBController::CURIUSBController(unsigned int address, bool checkInput) :
+m_address(address),
+m_checkInput(checkInput),
+m_outp1(false),
+m_outp3(false),
+m_outp5(false),
+m_outp6(false),
+m_context(NULL),
+m_handle(NULL)
+{
+	::libusb_init(&m_context);
+}
+
+CURIUSBController::~CURIUSBController()
+{
+	wxASSERT(m_context != NULL);
+
+	::libusb_exit(m_context);
+}
+
+bool CURIUSBController::open()
+{
+	wxASSERT(m_context != NULL);
+	wxASSERT(m_handle == NULL);
+
+	libusb_device** list;
+	ssize_t cnt = ::libusb_get_device_list(NULL, &list);
+	if (cnt <= 0) {
+		wxLogError(wxT("Cannot find any USB devices!"));
+		return false;
+	}
+
+	int err = 0;
+	unsigned int count = 0U;
+	for (ssize_t i = 0; i < cnt; i++) {
+		libusb_device_descriptor desc;
+		err = ::libusb_get_device_descriptor(list[i], &desc);
+		if (err < 0)
+			continue;
+
+		if (desc.idVendor == C108_VENDOR_ID     &&
+		   (desc.idProduct == C108_PRODUCT_ID   ||
+			desc.idProduct == C108AH_PRODUCT_ID ||
+			desc.idProduct == C119_PRODUCT_ID   ||
+			desc.idProduct == C119A_PRODUCT_ID)) {
+			count++;
+
+			// Is this the correct device?
+			if (count == m_address) {
+				err = ::libusb_open(list[i], &m_handle);
+		        break;
+		    }
+		}
+	}
+
+	if (err != 0) {
+		wxLogError(wxT("libusb_open failed, err=%d"), err);
+		::libusb_free_device_list(list, 1);
+		return false;
+	}
+
+	if (m_handle == NULL) {
+		wxLogError(wxT("Could not find a suitable CM108 based device"));
+		::libusb_free_device_list(list, 1);
+		return false;
+	}
+
+	::libusb_free_device_list(list, 1);
+
+	int res = ::libusb_claim_interface(m_handle, C108_HID_INTERFACE);
+	if (res != 0) {
+		res = ::libusb_detach_kernel_driver(m_handle, C108_HID_INTERFACE);
+		if (res != 0) {
+			wxLogError(wxT("libusb_detach_kernel_driver failed, err=%d"), res);
+			::libusb_close(m_handle);
+			m_handle = NULL;
+			return false;
+		}
+
+		res = ::libusb_claim_interface(m_handle, C108_HID_INTERFACE);
+		if (res != 0) {
+			wxLogError(wxT("libusb_claim_interface failed, err=%d"), res);
+			::libusb_close(m_handle);
+			m_handle = NULL;
+			return false;
+		}
+	}
+
+	setDigitalOutputs(false, false, false, false, false, false, false, false);
+
+	return true;
+}
+
+void CURIUSBController::getDigitalInputs(bool& inp1, bool& inp2, bool& inp3, bool& inp4, bool& inp5)
+{
+	wxASSERT(m_handle != NULL);
+
+	if (!m_checkInput) {
+		inp1 = inp2 = inp3 = inp4 = inp5 = false;
+		return;
+	}
+
+	unsigned char buffer[USB_BUFSIZE];
+	buffer[0] = 0x00;
+	buffer[1] = 0x00;
+	buffer[2] = 0x00;
+	buffer[3] = 0x00;
+	int res = ::libusb_control_transfer(m_handle, LIBUSB_ENDPOINT_IN + LIBUSB_REQUEST_TYPE_CLASS + LIBUSB_RECIPIENT_INTERFACE, HID_REPORT_GET, REPORT_ID + (HID_RT_INPUT << 8), C108_HID_INTERFACE, buffer, USB_BUFSIZE, USB_TIMEOUT);
+	if (res < 0) {
+		wxLogError(wxT("Error from libusb_control_transfer: err=%d"), res);
+		return;
+	}
+
+	if (res < USB_BUFSIZE)
+		return;
+
+	inp3 = false;
+
+	inp5 = (buffer[0] & HID_IR0_RM) == HID_IR0_RM;	// Disable
+	inp4 = (buffer[0] & HID_IR0_PM) == HID_IR0_PM;	// Battery
+	inp2 = (buffer[0] & HID_IR0_VU) == HID_IR0_VU;	// Squelch 2
+	inp1 = (buffer[0] & HID_IR0_VD) == HID_IR0_VD;	// Squelch 1
+}
+
+void CURIUSBController::setDigitalOutputs(bool outp1, bool, bool outp3, bool outp4, bool outp5, bool outp6, bool, bool)
+{
+	wxASSERT(m_handle != NULL);
+
+	if (outp1 == m_outp1 && outp3 == m_outp3 && outp5 == m_outp5 && outp6 == m_outp6)
+		return;
+
+	unsigned char buffer[USB_BUFSIZE];
+	buffer[0] = HID_OR0;
+	buffer[1] = HID_OR1;
+	buffer[2] = HID_OR2;
+	buffer[3] = HID_OR3;
+
+	if (outp1)			// Transmit
+		buffer[1] |= HID_OR1_GPIO3;
+	if (outp3)			// Heartbeat
+		buffer[1] |= HID_OR1_GPIO1;
+	if (outp4)			// Active
+		buffer[1] |= HID_OR1_GPIO2;
+	if (outp5)			// Output 1
+		buffer[1] |= HID_OR1_GPIO4;
+
+	int res = ::libusb_control_transfer(m_handle, LIBUSB_ENDPOINT_OUT + LIBUSB_REQUEST_TYPE_CLASS + LIBUSB_RECIPIENT_INTERFACE, HID_REPORT_SET, REPORT_ID + (HID_RT_OUTPUT << 8), C108_HID_INTERFACE, buffer, USB_BUFSIZE, USB_TIMEOUT);
+	if (res < 0) {
+		wxLogError(wxT("Error from libusb_control_transfer: err=%d"), res);
+		return;
+	}
+
+	if (res < USB_BUFSIZE)
+		return;
+
+	m_outp1 = outp1;
+	m_outp3 = outp3;
+	m_outp5 = outp5;
+	m_outp6 = outp6;
+}
+
+void CURIUSBController::close()
+{
+	wxASSERT(m_handle != NULL);
+
+	setDigitalOutputs(false, false, false, false, false, false, false, false);
+
+	::libusb_release_interface(m_handle, C108_HID_INTERFACE);
+
+	::libusb_close(m_handle);
+	m_handle = NULL;
+}
+
+#endif
+

--- a/DStarRepeater/Common/URIUSBController.h
+++ b/DStarRepeater/Common/URIUSBController.h
@@ -1,0 +1,55 @@
+/*
+ *	Copyright (C) 2009,2011 by Jonathan Naylor, G4KLX
+ *
+ *	This program is free software; you can redistribute it and/or modify
+ *	it under the terms of the GNU General Public License as published by
+ *	the Free Software Foundation; version 2 of the License.
+ *
+ *	This program is distributed in the hope that it will be useful,
+ *	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *	GNU General Public License for more details.
+ */
+
+#ifndef	URIUSBController_H
+#define	URIUSBController_H
+
+#include "HardwareController.h"
+
+#include <wx/wx.h>
+
+#if defined(__WINDOWS__)
+#include <windows.h>
+#else
+#include <libusb-1.0/libusb.h>
+#endif
+
+class CURIUSBController : public IHardwareController {
+public:
+	CURIUSBController(unsigned int address, bool checkInput);
+	virtual ~CURIUSBController();
+
+	virtual bool open();
+
+	virtual void getDigitalInputs(bool& inp1, bool& inp2, bool& inp3, bool& inp4, bool& inp5);
+
+	virtual void setDigitalOutputs(bool outp1, bool outp2, bool outp3, bool outp4, bool outp5, bool outp6, bool outp7, bool outp8);
+
+	virtual void close();
+
+private:
+	unsigned int          m_address;
+	bool                  m_checkInput;
+	bool                  m_outp1;
+	bool                  m_outp3;
+	bool                  m_outp5;
+	bool                  m_outp6;
+#if defined(__WINDOWS__)
+	HANDLE                m_handle;
+#else
+	libusb_context*       m_context;
+	libusb_device_handle* m_handle;
+#endif
+};
+
+#endif

--- a/DStarRepeater/DStarRepeater/DStarRepeaterApp.cpp
+++ b/DStarRepeater/DStarRepeater/DStarRepeaterApp.cpp
@@ -32,6 +32,7 @@
 #include "DVMegaController.h"
 #include "DStarRepeaterApp.h"
 #include "MMDVMController.h"
+#include "URIUSBController.h"
 #include "K8055Controller.h"
 #include "DummyController.h"
 #include "SplitController.h"
@@ -521,6 +522,10 @@ void CDStarRepeaterApp::createThread()
 		unsigned long num;
 		port.ToULong(&num);
 		controller = new CExternalController(new CK8055Controller(num), pttInvert);
+	} else if (controllerType.StartsWith(wxT("URI USB - "), &port)) {
+                unsigned long num;
+                port.ToULong(&num);
+                controller = new CExternalController(new CURIUSBController(num, true), pttInvert);
 	} else if (controllerType.StartsWith(wxT("Serial - "), &port)) {
 		controller = new CExternalController(new CSerialLineController(port, portConfig), pttInvert);
 	} else if (controllerType.StartsWith(wxT("Arduino - "), &port)) {

--- a/DStarRepeater/DStarRepeater/DStarRepeaterD.cpp
+++ b/DStarRepeater/DStarRepeater/DStarRepeaterD.cpp
@@ -30,6 +30,7 @@
 #include "ArduinoController.h"
 #include "DVMegaController.h"
 #include "MMDVMController.h"
+#include "URIUSBController.h"
 #include "K8055Controller.h"
 #include "DummyController.h"
 #include "SplitController.h"
@@ -452,6 +453,10 @@ bool CDStarRepeaterD::createThread()
 		unsigned long num;
 		port.ToULong(&num);
 		controller = new CExternalController(new CK8055Controller(num), pttInvert);
+	} else if (controllerType.StartsWith(wxT("URI USB - "), &port)) {
+                unsigned long num;
+                port.ToULong(&num);
+                controller = new CExternalController(new CURIUSBController(num, true), pttInvert);
 	} else if (controllerType.StartsWith(wxT("Serial - "), &port)) {
 		controller = new CExternalController(new CSerialLineController(port, portConfig), pttInvert);
 	} else if (controllerType.StartsWith(wxT("Arduino - "), &port)) {

--- a/DStarRepeater/DStarRepeater/Makefile
+++ b/DStarRepeater/DStarRepeater/Makefile
@@ -19,7 +19,7 @@ DStarRepeaterApp.o:	DStarRepeaterApp.cpp DStarRepeaterApp.h DStarRepeaterThread.
 					../Common/GMSKController.h ../Common/SoundCardController.h ../Common/DStarDefines.h ../Common/Logger.h ../Common/ExternalController.h \
 					../Common/RepeaterProtocolHandler.h ../Common/Version.h ../Common/CallsignList.h ../Common/DummyController.h ../Common/K8055Controller.h \
 					../Common/GPIOController.h ../Common/DStarRepeaterConfig.h ../Common/ArduinoController.h ../Common/SerialLineController.h \
-					../Common/DVMegaController.h ../Common/SplitController.h ../Common/MMDVMController.h
+					../Common/DVMegaController.h ../Common/SplitController.h ../Common/MMDVMController.h ../Common/URIUSBController.h
 				$(CC) $(CFLAGS) -c DStarRepeaterApp.cpp
 
 DStarRepeaterD.o:	DStarRepeaterD.cpp DStarRepeaterD.h DStarRepeaterThread.h DStarRepeaterTRXThread.h DStarRepeaterTXRXThread.h DStarRepeaterTXThread.h \
@@ -27,7 +27,7 @@ DStarRepeaterD.o:	DStarRepeaterD.cpp DStarRepeaterD.h DStarRepeaterThread.h DSta
 					../Common/DVRPTRV2Controller.h ../Common/DVRPTRV3Controller.h ../Common/SoundCardController.h ../Common/DStarDefines.h ../Common/Logger.h \
 					../Common/RepeaterProtocolHandler.h ../Common/Version.h ../Common/CallsignList.h ../Common/ExternalController.h ../Common/DummyController.h \
 					../Common/K8055Controller.h ../Common/GPIOController.h ../Common/ArduinoController.h ../Common/DStarRepeaterConfig.h \
-					../Common/SerialLineController.h ../Common/DVMegaController.h ../Common/SplitController.h ../Common/MMDVMController.h
+					../Common/SerialLineController.h ../Common/DVMegaController.h ../Common/SplitController.h ../Common/MMDVMController.h ../Common/URIUSBController.h
 				$(CC) $(CFLAGS) -c DStarRepeaterD.cpp
 
 DStarRepeaterFrame.o:	DStarRepeaterFrame.cpp DStarRepeaterFrame.h DStarRepeaterDefs.h DStarRepeaterApp.h DStarRepeaterStatusData.h ../Common/DStarDefines.h \

--- a/DStarRepeater/DStarRepeaterConfig/DStarRepeaterConfigControllerSet.cpp
+++ b/DStarRepeater/DStarRepeaterConfig/DStarRepeaterConfigControllerSet.cpp
@@ -51,6 +51,14 @@ m_time(NULL)
 	m_type->Append(wxT("Velleman K8055 - 2"));
 	m_type->Append(wxT("Velleman K8055 - 3"));
 
+	// Add the URI USB
+        m_type->Append(wxT("URI USB - 1"));
+        m_type->Append(wxT("URI USB - 2"));
+        m_type->Append(wxT("URI USB - 3"));
+        m_type->Append(wxT("URI USB - 4"));
+        m_type->Append(wxT("URI USB - 5"));
+        m_type->Append(wxT("URI USB - 6"));
+
 	// Add the Serial ports
 	wxArrayString serialDevs = CSerialPortSelector::getDevices();
 	for (size_t i = 0U; i < serialDevs.GetCount(); i++)

--- a/DStarRepeater/settings.mk
+++ b/DStarRepeater/settings.mk
@@ -1,12 +1,14 @@
 # Makefile-include
 #
-# Build the D-Star Repeater software on Linux with default settings (x86)
+# Build the D-Star Repeater software on Debian Linux with default settings (amd64)
+# Hans-J. Barthen, DL5DI, 2013-01-20
+# Rename this file to settings.mk before you compile the source for the Debian amd64 platform
 #
-	export DATADIR := "/usr/local/etc"
-	export BINDIR  := "/usr/local/bin"
-	export LOGDIR  := "/var/log"
-	export CONFDIR := "/etc"
+	export DATADIR := "/home/opendv/data"
+	export BINDIR  := $(DESTDIR)/usr/bin
+	export LOGDIR  := "/var/log/opendv"
+	export CONFDIR := "/home/opendv/dstarrepeater"
 	export CC      := $(shell wx-config --cxx)
 	export LDFLAGS := 
-	export CFLAGS  := -O2 -Wall -Wno-non-virtual-dtor -Wno-strict-aliasing -DLOG_DIR='$(LOGDIR)' -DCONF_DIR='$(CONFDIR)' -DDATA_DIR='$(DATADIR)' -DBIN_DIR='$(BINDIR)' $(shell wx-config --cxxflags)
+	export CFLAGS  := -O2 -m64 -Wall -Wno-non-virtual-dtor -Wno-strict-aliasing -DLOG_DIR='$(LOGDIR)' -DCONF_DIR='$(CONFDIR)' -DDATA_DIR='$(DATADIR)' -DBIN_DIR='$(BINDIR)' $(shell wx-config --cxxflags)
 	export LIBS    := -lasound -lusb-1.0 $(shell wx-config --libs adv,core)

--- a/DStarRepeater/settings.mk
+++ b/DStarRepeater/settings.mk
@@ -1,14 +1,12 @@
 # Makefile-include
 #
-# Build the D-Star Repeater software on Debian Linux with default settings (amd64)
-# Hans-J. Barthen, DL5DI, 2013-01-20
-# Rename this file to settings.mk before you compile the source for the Debian amd64 platform
+# Build the D-Star Repeater software on Linux with default settings (x86)
 #
-	export DATADIR := "/home/opendv/data"
-	export BINDIR  := $(DESTDIR)/usr/bin
-	export LOGDIR  := "/var/log/opendv"
-	export CONFDIR := "/home/opendv/dstarrepeater"
+	export DATADIR := "/usr/local/etc"
+	export BINDIR  := "/usr/local/bin"
+	export LOGDIR  := "/var/log"
+	export CONFDIR := "/etc"
 	export CC      := $(shell wx-config --cxx)
 	export LDFLAGS := 
-	export CFLAGS  := -O2 -m64 -Wall -Wno-non-virtual-dtor -Wno-strict-aliasing -DLOG_DIR='$(LOGDIR)' -DCONF_DIR='$(CONFDIR)' -DDATA_DIR='$(DATADIR)' -DBIN_DIR='$(BINDIR)' $(shell wx-config --cxxflags)
+	export CFLAGS  := -O2 -Wall -Wno-non-virtual-dtor -Wno-strict-aliasing -DLOG_DIR='$(LOGDIR)' -DCONF_DIR='$(CONFDIR)' -DDATA_DIR='$(DATADIR)' -DBIN_DIR='$(BINDIR)' $(shell wx-config --cxxflags)
 	export LIBS    := -lasound -lusb-1.0 $(shell wx-config --libs adv,core)


### PR DESCRIPTION
These changes add the ability to use a DMK Engineering URI device as a controller to trigger the PTT on the attached radio for the DStarRepeater application.