### PR TITLE
Enable compiling without GUI

### DIFF
--- a/DStarRepeater/Common/GatewayProtocolHandler.h
+++ b/DStarRepeater/Common/GatewayProtocolHandler.h
@@ -23,6 +23,7 @@
 #include "DStarDefines.h"
 
 #include <wx/wx.h>
+#include <wx/datetime.h>
 
 class CGatewayProtocolHandler {
 public:

--- a/DStarRepeater/Common/HeaderData.h
+++ b/DStarRepeater/Common/HeaderData.h
@@ -20,6 +20,7 @@
 #define	HeaderData_H
 
 #include <wx/wx.h>
+#include <wx/datetime.h>
 
 class CHeaderData {
 public:

--- a/DStarRepeater/DStarRepeater/DStarRepeaterRXThread.cpp
+++ b/DStarRepeater/DStarRepeater/DStarRepeaterRXThread.cpp
@@ -18,7 +18,6 @@
 
 #include "DStarRepeaterStatusData.h"
 #include "DStarRepeaterRXThread.h"
-#include "DStarRepeaterApp.h"
 #include "DVAPController.h"
 #include "DStarDefines.h"
 #include "HeaderData.h"

--- a/DStarRepeater/DStarRepeater/DStarRepeaterTRXThread.cpp
+++ b/DStarRepeater/DStarRepeater/DStarRepeaterTRXThread.cpp
@@ -18,7 +18,6 @@
 
 #include "DStarRepeaterStatusData.h"
 #include "DStarRepeaterTRXThread.h"
-#include "DStarRepeaterApp.h"
 #include "DVAPController.h"
 #include "DStarDefines.h"
 #include "HeaderData.h"

--- a/DStarRepeater/DStarRepeater/DStarRepeaterTXRXThread.cpp
+++ b/DStarRepeater/DStarRepeater/DStarRepeaterTXRXThread.cpp
@@ -18,7 +18,6 @@
 
 #include "DStarRepeaterStatusData.h"
 #include "DStarRepeaterTXRXThread.h"
-#include "DStarRepeaterApp.h"
 #include "DVAPController.h"
 #include "DStarDefines.h"
 #include "HeaderData.h"

--- a/DStarRepeater/DStarRepeater/DStarRepeaterTXThread.cpp
+++ b/DStarRepeater/DStarRepeater/DStarRepeaterTXThread.cpp
@@ -18,7 +18,6 @@
 
 #include "DStarRepeaterStatusData.h"
 #include "DStarRepeaterTXThread.h"
-#include "DStarRepeaterApp.h"
 #include "DStarDefines.h"
 #include "HeaderData.h"
 #include "Version.h"


### PR DESCRIPTION
wxWidgets has the capability to compile with only the "base" library.
To do so, you must set the wxUSE_GUI=0 preprocessor directive when compiling.
This will disable a few things such as dragging in the some of the include
files.  So, in order to get wxDateTime, you have to manually include it.  It
no longer comes in by just including wx/wx.h.  Additionally there were a few
files in DStarRepeater that bring in DStarRepeaterApp.h that really don't
need it.