### PR TITLE
Cleaning up the GMSK Modem LibUSB dependencies

### DIFF
--- a/DStarRepeater/Common/GMSKModemLibUsb.cpp
+++ b/DStarRepeater/Common/GMSKModemLibUsb.cpp
@@ -111,6 +111,8 @@ m_context(NULL)
 	wxLogMessage(wxT("Successfully loaded library %s"), LIBNAME.c_str());
 	
 	m_loaded = true;
+#else
+	::libusb_init(&m_context);
 #endif
 }
 

--- a/DStarRepeater/Common/GMSKModemLibUsb.cpp
+++ b/DStarRepeater/Common/GMSKModemLibUsb.cpp
@@ -159,12 +159,7 @@ bool CGMSKModemLibUsb::open()
 			wxString text((char *) buffer, wxConvLocal, ret2);
 			version.Append(text);
 		} else if (ret2 < 0) {
-#if defined(WIN32)
-			wxString error(m_usbStrerror(), wxConvLocal);
-#else
-			wxString error(libusb_error_name(ret2), wxConvLocal);
-#endif
-			wxLogError(wxT("GET_VERSION, ret: %d, err=%s"), ret2, error.c_str());
+			::libUsbLogError(ret2, "GET_VERSION");
 			close();
 			return false;
 		}

--- a/DStarRepeater/Common/GMSKModemLibUsb.h
+++ b/DStarRepeater/Common/GMSKModemLibUsb.h
@@ -73,13 +73,13 @@ private:
 	static char*           (*m_usbStrerror)();
 	static int             (*m_usbClose)(usb_dev_handle*);
 
-	int io(int requestType, int request, int value, int index, char* bytes, int size, int timeout);
 #else
 	libusb_context*          m_context;
-	libusb_device_handle*    m_handle;
+	libusb_device_handle*    m_dev;
 
-	int io(uint8_t requestType, uint8_t request, uint16_t value, uint16_t index, unsigned char* data, uint16_t length, unsigned int timeout);
 #endif
+	int io(uint8_t requestType, uint8_t request, uint16_t value, uint16_t index, unsigned char* data, uint16_t length, unsigned int timeout);
+
 	bool                     m_brokenSpace;
 
 	bool openModem();


### PR DESCRIPTION
There are a lot of files in the tree with huge #ifdefs around the entire file.  This isn't really optimal as it doesn't allow much code sharing among the ports and causes things to slip from being in sync and getting fixed.  This file is one of those that shares a lot of commonality but has redundant code.  This patch separates out the things that are truly different and puts them in separate preprocessor conditionals.

That being said, there is a WinUSB piece for Windows users which, I assume, is preferred over using LibUSB on that platform.  Especially since the URI and K8055 drivers only use WinUSB on Windows.  If that's the case, we probably shouldn't even give Windows users a choice and make this a Linux-only file and drop it from the Windows build project files.  Otherwise, this targets the libusb-0.1 library and probably should be updated to use the libusb-1.0 library which is available on Windows now in the main tree.