### PR TITLE
Update the wxWidgets version check

### DIFF
--- a/DStarRepeater/configure
+++ b/DStarRepeater/configure
@@ -5089,7 +5089,7 @@ else
 fi
 
 
-reqwx=2.4.0
+reqwx=3.0.0
 
 
     if test x${WX_CONFIG_NAME+set} != xset ; then

--- a/DStarRepeater/configure.ac
+++ b/DStarRepeater/configure.ac
@@ -33,7 +33,7 @@ AC_PROG_RANLIB
 
 # Checks for libraries.
 AM_OPTIONS_WXCONFIG
-reqwx=2.4.0
+reqwx=3.0.0
 AM_PATH_WXCONFIG($reqwx, wxWin=1)
 if test "$wxWin" != 1; then
 	AC_MSG_ERROR([


### PR DESCRIPTION
I am informed that wxWidgets 2.x is considered obsolete and we are using things
that will not compile with it in other portions of the project.  This patch
updates configure.ac to require wxWidgets 3.0 to pass the checks.