### PR TITLE
Add the creation of log directories in the UNIX build

### DIFF
--- a/AnalogueRepeater/.gitignore
+++ b/AnalogueRepeater/.gitignore
@@ -1,0 +1,2 @@
+analoguerepeater
+analoguerepeaterd

--- a/DStarRepeater/.gitignore
+++ b/DStarRepeater/.gitignore
@@ -1,0 +1,5 @@
+dstarrepeaterd
+dstarrepeater
+dstarrepeaterconfig
+LinuxUSB/rmk8055drv
+LinuxUSB/rmuridrv

--- a/DStarRepeater/Makefile.am
+++ b/DStarRepeater/Makefile.am
@@ -1,8 +1,11 @@
 SUBDIRS = LinuxUSB 
 
+opendvlogdir = ${localstatedir}/log/opendv
+opendvlog_DATA = 
+
 DEFS += \
 	-DDATA_DIR=\"${datadir}\" \
-	-DLOG_DIR=\"${localstatedir}/log/opendv\" \
+	-DLOG_DIR=\"${opendvlogdir}\" \
         -DCONF_DIR=\"${sysconfdir}\"
 
 CONTROLLER_SRCS =  Common/ArduinoController.cpp \

--- a/DStarRepeater/Makefile.am
+++ b/DStarRepeater/Makefile.am
@@ -6,7 +6,7 @@ opendvlog_DATA =
 DEFS += \
 	-DDATA_DIR=\"${datadir}\" \
 	-DLOG_DIR=\"${opendvlogdir}\" \
-        -DCONF_DIR=\"${sysconfdir}\"
+    -DCONF_DIR=\"${sysconfdir}\"
 
 CONTROLLER_SRCS =  Common/ArduinoController.cpp \
                    Common/DummyController.cpp \

--- a/DStarRepeater/Makefile.in
+++ b/DStarRepeater/Makefile.in
@@ -14,6 +14,7 @@
 
 @SET_MAKE@
 
+
 VPATH = @srcdir@
 am__is_gnu_make = { \
   if test -z '$(MAKELEVEL)'; then \
@@ -104,7 +105,8 @@ am__CONFIG_DISTCLEAN_FILES = config.status config.cache config.log \
 mkinstalldirs = $(install_sh) -d
 CONFIG_CLEAN_FILES =
 CONFIG_CLEAN_VPATH_FILES =
-am__installdirs = "$(DESTDIR)$(bindir)" "$(DESTDIR)$(sbindir)"
+am__installdirs = "$(DESTDIR)$(bindir)" "$(DESTDIR)$(sbindir)" \
+	"$(DESTDIR)$(opendvlogdir)"
 PROGRAMS = $(bin_PROGRAMS) $(sbin_PROGRAMS)
 am__dstarrepeater_SOURCES_DIST = DStarRepeater/DStarRepeaterApp.cpp \
 	DStarRepeater/DStarRepeaterFrame.cpp \
@@ -410,6 +412,34 @@ am__can_run_installinfo = \
     n|no|NO) false;; \
     *) (install-info --version) >/dev/null 2>&1;; \
   esac
+am__vpath_adj_setup = srcdirstrip=`echo "$(srcdir)" | sed 's|.|.|g'`;
+am__vpath_adj = case $$p in \
+    $(srcdir)/*) f=`echo "$$p" | sed "s|^$$srcdirstrip/||"`;; \
+    *) f=$$p;; \
+  esac;
+am__strip_dir = f=`echo $$p | sed -e 's|^.*/||'`;
+am__install_max = 40
+am__nobase_strip_setup = \
+  srcdirstrip=`echo "$(srcdir)" | sed 's/[].[^$$\\*|]/\\\\&/g'`
+am__nobase_strip = \
+  for p in $$list; do echo "$$p"; done | sed -e "s|$$srcdirstrip/||"
+am__nobase_list = $(am__nobase_strip_setup); \
+  for p in $$list; do echo "$$p $$p"; done | \
+  sed "s| $$srcdirstrip/| |;"' / .*\//!s/ .*/ ./; s,\( .*\)/[^/]*$$,\1,' | \
+  $(AWK) 'BEGIN { files["."] = "" } { files[$$2] = files[$$2] " " $$1; \
+    if (++n[$$2] == $(am__install_max)) \
+      { print $$2, files[$$2]; n[$$2] = 0; files[$$2] = "" } } \
+    END { for (dir in files) print dir, files[dir] }'
+am__base_list = \
+  sed '$$!N;$$!N;$$!N;$$!N;$$!N;$$!N;$$!N;s/\n/ /g' | \
+  sed '$$!N;$$!N;$$!N;$$!N;s/\n/ /g'
+am__uninstall_files_from_dir = { \
+  test -z "$$files" \
+    || { test ! -d "$$dir" && test ! -f "$$dir" && test ! -r "$$dir"; } \
+    || { echo " ( cd '$$dir' && rm -f" $$files ")"; \
+         $(am__cd) "$$dir" && rm -f $$files; }; \
+  }
+DATA = $(opendvlog_DATA)
 RECURSIVE_CLEAN_TARGETS = mostlyclean-recursive clean-recursive	\
   distclean-recursive maintainer-clean-recursive
 am__recursive_targets = \
@@ -503,8 +533,7 @@ CXX = @CXX@
 CXXDEPMODE = @CXXDEPMODE@
 CXXFLAGS = @CXXFLAGS@
 CYGPATH_W = @CYGPATH_W@
-DEFS = @DEFS@ -DDATA_DIR=\"${datadir}\" \
-	-DLOG_DIR=\"${localstatedir}/log/opendv\" \
+DEFS = @DEFS@ -DDATA_DIR=\"${datadir}\" -DLOG_DIR=\"${opendvlogdir}\" \
 	-DCONF_DIR=\"${sysconfdir}\"
 DEPDIR = @DEPDIR@
 ECHO_C = @ECHO_C@
@@ -602,6 +631,8 @@ top_build_prefix = @top_build_prefix@
 top_builddir = @top_builddir@
 top_srcdir = @top_srcdir@
 SUBDIRS = LinuxUSB 
+opendvlogdir = ${localstatedir}/log/opendv
+opendvlog_DATA = 
 CONTROLLER_SRCS = Common/ArduinoController.cpp \
                    Common/DummyController.cpp \
                    Common/DVAPController.cpp \
@@ -3325,6 +3356,27 @@ Common/dstarrepeaterd-URIUSBController.obj: Common/URIUSBController.cpp
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='Common/URIUSBController.cpp' object='Common/dstarrepeaterd-URIUSBController.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(dstarrepeaterd_CPPFLAGS) $(CPPFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS) -c -o Common/dstarrepeaterd-URIUSBController.obj `if test -f 'Common/URIUSBController.cpp'; then $(CYGPATH_W) 'Common/URIUSBController.cpp'; else $(CYGPATH_W) '$(srcdir)/Common/URIUSBController.cpp'; fi`
+install-opendvlogDATA: $(opendvlog_DATA)
+	@$(NORMAL_INSTALL)
+	@list='$(opendvlog_DATA)'; test -n "$(opendvlogdir)" || list=; \
+	if test -n "$$list"; then \
+	  echo " $(MKDIR_P) '$(DESTDIR)$(opendvlogdir)'"; \
+	  $(MKDIR_P) "$(DESTDIR)$(opendvlogdir)" || exit 1; \
+	fi; \
+	for p in $$list; do \
+	  if test -f "$$p"; then d=; else d="$(srcdir)/"; fi; \
+	  echo "$$d$$p"; \
+	done | $(am__base_list) | \
+	while read files; do \
+	  echo " $(INSTALL_DATA) $$files '$(DESTDIR)$(opendvlogdir)'"; \
+	  $(INSTALL_DATA) $$files "$(DESTDIR)$(opendvlogdir)" || exit $$?; \
+	done
+
+uninstall-opendvlogDATA:
+	@$(NORMAL_UNINSTALL)
+	@list='$(opendvlog_DATA)'; test -n "$(opendvlogdir)" || list=; \
+	files=`for p in $$list; do echo $$p; done | sed -e 's|^.*/||'`; \
+	dir='$(DESTDIR)$(opendvlogdir)'; $(am__uninstall_files_from_dir)
 
 # This directory's subdirectories are mostly independent; you can cd
 # into them and run 'make' without going through this Makefile.
@@ -3622,10 +3674,10 @@ distcleancheck: distclean
 	       exit 1; } >&2
 check-am: all-am
 check: check-recursive
-all-am: Makefile $(PROGRAMS)
+all-am: Makefile $(PROGRAMS) $(DATA)
 installdirs: installdirs-recursive
 installdirs-am:
-	for dir in "$(DESTDIR)$(bindir)" "$(DESTDIR)$(sbindir)"; do \
+	for dir in "$(DESTDIR)$(bindir)" "$(DESTDIR)$(sbindir)" "$(DESTDIR)$(opendvlogdir)"; do \
 	  test -z "$$dir" || $(MKDIR_P) "$$dir"; \
 	done
 install: install-recursive
@@ -3690,7 +3742,7 @@ info: info-recursive
 
 info-am:
 
-install-data-am:
+install-data-am: install-opendvlogDATA
 
 install-dvi: install-dvi-recursive
 
@@ -3737,7 +3789,8 @@ ps: ps-recursive
 
 ps-am:
 
-uninstall-am: uninstall-binPROGRAMS uninstall-sbinPROGRAMS
+uninstall-am: uninstall-binPROGRAMS uninstall-opendvlogDATA \
+	uninstall-sbinPROGRAMS
 
 .MAKE: $(am__recursive_targets) install-am install-strip
 
@@ -3752,12 +3805,13 @@ uninstall-am: uninstall-binPROGRAMS uninstall-sbinPROGRAMS
 	install-binPROGRAMS install-data install-data-am install-dvi \
 	install-dvi-am install-exec install-exec-am install-html \
 	install-html-am install-info install-info-am install-man \
-	install-pdf install-pdf-am install-ps install-ps-am \
-	install-sbinPROGRAMS install-strip installcheck \
+	install-opendvlogDATA install-pdf install-pdf-am install-ps \
+	install-ps-am install-sbinPROGRAMS install-strip installcheck \
 	installcheck-am installdirs installdirs-am maintainer-clean \
 	maintainer-clean-generic mostlyclean mostlyclean-compile \
 	mostlyclean-generic pdf pdf-am ps ps-am tags tags-am uninstall \
-	uninstall-am uninstall-binPROGRAMS uninstall-sbinPROGRAMS
+	uninstall-am uninstall-binPROGRAMS uninstall-opendvlogDATA \
+	uninstall-sbinPROGRAMS
 
 .PRECIOUS: Makefile
 

--- a/DummyRepeater/.gitignore
+++ b/DummyRepeater/.gitignore
@@ -1,0 +1,3 @@
+AMBEserver
+dummyrepeater
+dvemu

--- a/XReflector/.gitignore
+++ b/XReflector/.gitignore
@@ -1,0 +1,2 @@
+xreflector
+xreflectord

--- a/ircDDBGateway/.gitignore
+++ b/ircDDBGateway/.gitignore
@@ -1,0 +1,14 @@
+aprstransmit
+aprstransmitd
+ircddbgateway
+ircddbgatewayconfig
+ircddbgatewayd
+remotecontrol
+starnetserver
+starnetserverd
+texttransmit
+timercontrol
+timercontrold
+timeserver
+timeserverd
+voicetransmit

--- a/ircDDBGateway/Makefile.am
+++ b/ircDDBGateway/Makefile.am
@@ -1,6 +1,9 @@
+opendvlogdir = ${localstatedir}/log/opendv
+opendvlog_DATA = 
+
 DEFS += \
 	-DDATA_DIR=\"${pkgdatadir}\" \
-	-DLOG_DIR=\"${localstatedir}/log/opendv\" \
+	-DLOG_DIR=\"${opendvlogdir}\" \
     -DCONF_DIR=\"${sysconfdir}\"
     
 STARNETSERVER_COMMON = \

--- a/ircDDBGateway/Makefile.am
+++ b/ircDDBGateway/Makefile.am
@@ -1,8 +1,7 @@
 DEFS += \
 	-DDATA_DIR=\"${pkgdatadir}\" \
 	-DLOG_DIR=\"${localstatedir}/log/opendv\" \
-    -DCONF_DIR=\"${sysconfdir}\" \
-    -DBIN_DIR=\"${bindir}\"
+    -DCONF_DIR=\"${sysconfdir}\"
     
 STARNETSERVER_COMMON = \
 	StarNetServer/StarNetServerConfig.cpp \

--- a/ircDDBGateway/Makefile.in
+++ b/ircDDBGateway/Makefile.in
@@ -218,7 +218,7 @@ libircDDB_a_OBJECTS = $(am_libircDDB_a_OBJECTS)
 @WITH_GUI_TRUE@	aprstransmit$(EXEEXT) timercontrol$(EXEEXT) \
 @WITH_GUI_TRUE@	timeserver$(EXEEXT)
 am__installdirs = "$(DESTDIR)$(bindir)" "$(DESTDIR)$(sbindir)" \
-	"$(DESTDIR)$(pkgdatadir)"
+	"$(DESTDIR)$(opendvlogdir)" "$(DESTDIR)$(pkgdatadir)"
 PROGRAMS = $(bin_PROGRAMS) $(sbin_PROGRAMS)
 am__aprstransmit_SOURCES_DIST = APRSTransmit/APRSTransmitApp.cpp \
 	APRSTransmit/APRSParser.cpp APRSTransmit/APRSTransmit.cpp
@@ -493,7 +493,7 @@ am__uninstall_files_from_dir = { \
     || { echo " ( cd '$$dir' && rm -f" $$files ")"; \
          $(am__cd) "$$dir" && rm -f $$files; }; \
   }
-DATA = $(pkgdata_DATA)
+DATA = $(opendvlog_DATA) $(pkgdata_DATA)
 am__tagged_files = $(HEADERS) $(SOURCES) $(TAGS_FILES) $(LISP)
 # Read a list of newline-separated strings from the standard input,
 # and print each of them once, without duplicates.  Input order is
@@ -554,8 +554,7 @@ CXXDEPMODE = @CXXDEPMODE@
 CXXFLAGS = @CXXFLAGS@
 CYGPATH_W = @CYGPATH_W@
 DEFS = @DEFS@ -DDATA_DIR=\"${pkgdatadir}\" \
-	-DLOG_DIR=\"${localstatedir}/log/opendv\" \
-	-DCONF_DIR=\"${sysconfdir}\" -DBIN_DIR=\"${bindir}\"
+	-DLOG_DIR=\"${opendvlogdir}\" -DCONF_DIR=\"${sysconfdir}\"
 DEPDIR = @DEPDIR@
 ECHO_C = @ECHO_C@
 ECHO_N = @ECHO_N@
@@ -646,6 +645,8 @@ target_alias = @target_alias@
 top_build_prefix = @top_build_prefix@
 top_builddir = @top_builddir@
 top_srcdir = @top_srcdir@
+opendvlogdir = ${localstatedir}/log/opendv
+opendvlog_DATA = 
 STARNETSERVER_COMMON = \
 	StarNetServer/StarNetServerConfig.cpp \
 	StarNetServer/StarNetServerThread.cpp
@@ -4084,6 +4085,27 @@ VoiceTransmit/voicetransmit-VoiceStore.obj: VoiceTransmit/VoiceStore.cpp
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='VoiceTransmit/VoiceStore.cpp' object='VoiceTransmit/voicetransmit-VoiceStore.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(voicetransmit_CPPFLAGS) $(CPPFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS) -c -o VoiceTransmit/voicetransmit-VoiceStore.obj `if test -f 'VoiceTransmit/VoiceStore.cpp'; then $(CYGPATH_W) 'VoiceTransmit/VoiceStore.cpp'; else $(CYGPATH_W) '$(srcdir)/VoiceTransmit/VoiceStore.cpp'; fi`
+install-opendvlogDATA: $(opendvlog_DATA)
+	@$(NORMAL_INSTALL)
+	@list='$(opendvlog_DATA)'; test -n "$(opendvlogdir)" || list=; \
+	if test -n "$$list"; then \
+	  echo " $(MKDIR_P) '$(DESTDIR)$(opendvlogdir)'"; \
+	  $(MKDIR_P) "$(DESTDIR)$(opendvlogdir)" || exit 1; \
+	fi; \
+	for p in $$list; do \
+	  if test -f "$$p"; then d=; else d="$(srcdir)/"; fi; \
+	  echo "$$d$$p"; \
+	done | $(am__base_list) | \
+	while read files; do \
+	  echo " $(INSTALL_DATA) $$files '$(DESTDIR)$(opendvlogdir)'"; \
+	  $(INSTALL_DATA) $$files "$(DESTDIR)$(opendvlogdir)" || exit $$?; \
+	done
+
+uninstall-opendvlogDATA:
+	@$(NORMAL_UNINSTALL)
+	@list='$(opendvlog_DATA)'; test -n "$(opendvlogdir)" || list=; \
+	files=`for p in $$list; do echo $$p; done | sed -e 's|^.*/||'`; \
+	dir='$(DESTDIR)$(opendvlogdir)'; $(am__uninstall_files_from_dir)
 install-pkgdataDATA: $(pkgdata_DATA)
 	@$(NORMAL_INSTALL)
 	@list='$(pkgdata_DATA)'; test -n "$(pkgdatadir)" || list=; \
@@ -4332,7 +4354,7 @@ check-am: all-am
 check: check-am
 all-am: Makefile $(LIBRARIES) $(PROGRAMS) $(DATA)
 installdirs:
-	for dir in "$(DESTDIR)$(bindir)" "$(DESTDIR)$(sbindir)" "$(DESTDIR)$(pkgdatadir)"; do \
+	for dir in "$(DESTDIR)$(bindir)" "$(DESTDIR)$(sbindir)" "$(DESTDIR)$(opendvlogdir)" "$(DESTDIR)$(pkgdatadir)"; do \
 	  test -z "$$dir" || $(MKDIR_P) "$$dir"; \
 	done
 install: install-am
@@ -4413,7 +4435,7 @@ info: info-am
 
 info-am:
 
-install-data-am: install-pkgdataDATA
+install-data-am: install-opendvlogDATA install-pkgdataDATA
 
 install-dvi: install-dvi-am
 
@@ -4460,8 +4482,8 @@ ps: ps-am
 
 ps-am:
 
-uninstall-am: uninstall-binPROGRAMS uninstall-pkgdataDATA \
-	uninstall-sbinPROGRAMS
+uninstall-am: uninstall-binPROGRAMS uninstall-opendvlogDATA \
+	uninstall-pkgdataDATA uninstall-sbinPROGRAMS
 
 .MAKE: install-am install-strip
 
@@ -4475,14 +4497,14 @@ uninstall-am: uninstall-binPROGRAMS uninstall-pkgdataDATA \
 	html-am info info-am install install-am install-binPROGRAMS \
 	install-data install-data-am install-dvi install-dvi-am \
 	install-exec install-exec-am install-html install-html-am \
-	install-info install-info-am install-man install-pdf \
-	install-pdf-am install-pkgdataDATA install-ps install-ps-am \
-	install-sbinPROGRAMS install-strip installcheck \
+	install-info install-info-am install-man install-opendvlogDATA \
+	install-pdf install-pdf-am install-pkgdataDATA install-ps \
+	install-ps-am install-sbinPROGRAMS install-strip installcheck \
 	installcheck-am installdirs maintainer-clean \
 	maintainer-clean-generic mostlyclean mostlyclean-compile \
 	mostlyclean-generic pdf pdf-am ps ps-am tags tags-am uninstall \
-	uninstall-am uninstall-binPROGRAMS uninstall-pkgdataDATA \
-	uninstall-sbinPROGRAMS
+	uninstall-am uninstall-binPROGRAMS uninstall-opendvlogDATA \
+	uninstall-pkgdataDATA uninstall-sbinPROGRAMS
 
 .PRECIOUS: Makefile
 


### PR DESCRIPTION
As requested in comments to #74 by F4FXL.  This adds log directory creation to the UNIX builds of DStarRepeater and ircDDBGateway.