### PR TITLE
ircDDBGateway:  Fix calculation of APRS passcode

### DIFF
--- a/ircDDBGateway/Common/APRSWriterThread.cpp
+++ b/ircDDBGateway/Common/APRSWriterThread.cpp
@@ -255,7 +255,8 @@ unsigned int CAPRSWriterThread::getAPRSPassword(wxString callsign) const
 
 	for (unsigned int i = 0U; i < len; i += 2U) {
 		hash ^= (char)callsign.GetChar(i) << 8;
-		if(i + 1 < len - 1) hash ^= (char)callsign.GetChar(i + 1);
+		if(i + 1 < len)
+			hash ^= (char)callsign.GetChar(i + 1);
 	}
 
 	return hash & 0x7FFFU;


### PR DESCRIPTION
Commit 0c94962 tried to fix the passcode generation of APRS checksums, but
failed.  The issue is that the C version in Xastir uses a C string that is
extra large and includes the terminating NULL at the end.  The loop in
ircDDBGateway using wxWidgets doesn't have this extra padding at the end.
This means that sometimes the loop can try to overflow the string when it's
getting the individual characters to calculate the passcode.  The last
committer changed this so that it would attempt to not overflow the end
of the string with an if() statement.

The problem here is that the string is 0 indexed, not 1 indexed.  There is
an off-by-one error in the if() statement that causes it not to calculate
the checksum of the last character in certain cases.  This patch should fix
that.