### PR TITLE
Fixed Broken Windows Build, minor changes in APRStransmitAppD

### DIFF
--- a/ircDDBGateway/APRSTransmit/APRSTransmitAppD.cpp
+++ b/ircDDBGateway/APRSTransmit/APRSTransmitAppD.cpp
@@ -48,7 +48,7 @@ static void handler(int signum)
 static void aprsFrameCallback(const wxString& aprsFrame)
 {
 	//wxLogMessage(wxT("Received APRS Fram : ") + aprsFrame);
-	m_aprsTransmit->m_aprsFramesQueue->addData(new wxString(aprsFrame));
+	m_aprsTransmit->m_aprsFramesQueue->addData(new wxString(aprsFrame.Clone()));
 }
 
 int main(int argc, char** argv)

--- a/ircDDBGateway/APRSTransmit/APRSTransmitAppD.cpp
+++ b/ircDDBGateway/APRSTransmit/APRSTransmitAppD.cpp
@@ -95,7 +95,7 @@ int main(int argc, char** argv)
 	long radius;
 	if(!parser.Found(REPEATER_RADIUS, &radius))
 		radius = 50;
-	wxString aprsFilter(repeater);
+	wxString aprsFilter = repeater.Clone();
 	aprsFilter.resize(LONG_CALLSIGN_LENGTH - 1, wxT(' '));
 	aprsFilter.Trim(true);
 	wxString ssid = repeater.SubString(LONG_CALLSIGN_LENGTH - 1, 1); 

--- a/ircDDBGateway/APRSTransmit/APRSTransmitAppD.cpp
+++ b/ircDDBGateway/APRSTransmit/APRSTransmitAppD.cpp
@@ -95,8 +95,7 @@ int main(int argc, char** argv)
 	long radius;
 	if(!parser.Found(REPEATER_RADIUS, &radius))
 		radius = 50;
-	wxString aprsFilter = repeater.Clone();
-	aprsFilter.resize(LONG_CALLSIGN_LENGTH - 1, wxT(' '));
+	wxString aprsFilter = repeater.SubString(0, SHORT_CALLSIGN_LENGTH);
 	aprsFilter.Trim(true);
 	wxString ssid = repeater.SubString(LONG_CALLSIGN_LENGTH - 1, 1); 
 	aprsFilter << wxT("-") << ssid;

--- a/ircDDBGateway/Common/Logger.cpp
+++ b/ircDDBGateway/Common/Logger.cpp
@@ -20,7 +20,7 @@
 
 CLogger::CLogger(const wxString& directory, const wxString& name) :
 #if(defined(__WINDOWS__))
-m_day(0)
+m_day(0),
 #endif
 wxLog(),
 m_name(name),


### PR DESCRIPTION
Logger.cpp did not compile under Windows this fixes that and adds some more security in string cross thread access in APRSTransmitAppD

73
Geoffrey F4FXL / KC3FRA