### PR TITLE
Removed check for empty password, this prevents connection to openquad

### DIFF
--- a/ircDDBGateway/StarNetServer/StarNetServerApp.cpp
+++ b/ircDDBGateway/StarNetServer/StarNetServerApp.cpp
@@ -557,7 +557,7 @@ void CStarNetServerApp::createThread()
 	getIrcDDB(hostname, username, password);
 	wxLogInfo(wxT("ircDDB host set to %s, username set to %s"), hostname.c_str(), username.c_str());
 
-	if (!hostname.IsEmpty() && !username.IsEmpty() && !password.IsEmpty()) {
+	if (!hostname.IsEmpty() && !username.IsEmpty()) {
 #if defined(__WINDOWS__)
 		CIRCDDB* ircDDB = new CIRCDDBClient(hostname, 9007U, username, password, wxT("win_") + LOG_BASE_NAME + wxT("-") + VERSION, address); 
 #else

--- a/ircDDBGateway/StarNetServer/StarNetServerAppD.cpp
+++ b/ircDDBGateway/StarNetServer/StarNetServerAppD.cpp
@@ -170,7 +170,7 @@ bool CStarNetServerAppD::createThread()
 	config.getIrcDDB(hostname, username, password);
 	wxLogInfo(wxT("ircDDB host set to %s, username set to %s"), hostname.c_str(), username.c_str());
 
-	if (!hostname.IsEmpty() && !username.IsEmpty() && !password.IsEmpty()) {
+	if (!hostname.IsEmpty() && !username.IsEmpty()) {
 #if defined(__WINDOWS__)
 		CIRCDDB* ircDDB = new CIRCDDBClient(hostname, 9007U, username, password, wxT("win_") + LOG_BASE_NAME + wxT("-") + VERSION, address); 
 #else


### PR DESCRIPTION
Hi,

I just started to enable multiple IRCDDB networks on StarneServer and stumbled over this.
OpenQuad does not have passswords, thus leaving the field empty will cause the connection to never be established.

73
Geoffrey F4FXL / KC3FRA