### PR TITLE
Add XLX reflector list download capability

### DIFF
--- a/ircDDBGateway/Common/IRCDDBGatewayConfig.cpp
+++ b/ircDDBGateway/Common/IRCDDBGatewayConfig.cpp
@@ -139,6 +139,8 @@ const wxString  KEY_DPLUS_LOGIN          = wxT("dplusLogin");
 const wxString  KEY_DCS_ENABLED          = wxT("dcsEnabled");
 const wxString  KEY_CCS_ENABLED          = wxT("ccsEnabled");
 const wxString  KEY_CCS_HOST             = wxT("ccsHost");
+const wxString  KEY_XLX_ENABLED		 = wxT("xlxEnabled");
+const wxString  KEY_XLX_HOSTS_FILE_URL	 = wxT("xlxHostsFileUrl");
 const wxString  KEY_STARNET_BAND1            = wxT("starNetBand1");
 const wxString  KEY_STARNET_CALLSIGN1        = wxT("starNetCallsign1");
 const wxString  KEY_STARNET_LOGOFF1          = wxT("starNetLogoff1");
@@ -258,6 +260,8 @@ const wxString     DEFAULT_DPLUS_LOGIN           = wxEmptyString;
 const bool         DEFAULT_DCS_ENABLED           = true;
 const bool         DEFAULT_CCS_ENABLED           = true;
 const wxString     DEFAULT_CCS_HOST              = wxT("CCS704  ");
+const bool	   DEFAULT_XLX_ENABLED		 = true;
+const wxString	   DEFAULT_XLX_HOSTS_FILE_URL	 = wxT("http://xlxapi.rlx.lu/api.php?do=GetReflectorHostname");
 const wxString     DEFAULT_STARNET_BAND          = wxEmptyString;
 const wxString     DEFAULT_STARNET_CALLSIGN      = wxEmptyString;
 const wxString     DEFAULT_STARNET_LOGOFF        = wxEmptyString;
@@ -406,6 +410,8 @@ m_dplusLogin(DEFAULT_DPLUS_LOGIN),
 m_dcsEnabled(DEFAULT_DCS_ENABLED),
 m_ccsEnabled(DEFAULT_CCS_ENABLED),
 m_ccsHost(DEFAULT_CCS_HOST),
+m_xlxEnabled(DEFAULT_XLX_ENABLED),
+m_xlxHostsFileUrl(DEFAULT_XLX_HOSTS_FILE_URL),
 m_starNet1Band(DEFAULT_STARNET_BAND),
 m_starNet1Callsign(DEFAULT_STARNET_CALLSIGN),
 m_starNet1Logoff(DEFAULT_STARNET_LOGOFF),
@@ -736,6 +742,10 @@ m_y(DEFAULT_WINDOW_Y)
 	m_config->Read(m_name + KEY_CCS_ENABLED, &m_ccsEnabled, DEFAULT_CCS_ENABLED);
 
 	m_config->Read(m_name + KEY_CCS_HOST, &m_ccsHost, DEFAULT_CCS_HOST);
+	
+	m_config->Read(m_name + KEY_XLX_ENABLED, &m_xlxEnabled, DEFAULT_XLX_ENABLED);
+	
+	m_config->Read(m_name + KEY_XLX_HOSTS_FILE_URL, &m_xlxHostsFileUrl, DEFAULT_XLX_HOSTS_FILE_URL);
 
 	m_config->Read(m_name + KEY_STARNET_BAND1, &m_starNet1Band, DEFAULT_STARNET_BAND);
 
@@ -1007,6 +1017,8 @@ m_dplusLogin(DEFAULT_DPLUS_LOGIN),
 m_dcsEnabled(DEFAULT_DCS_ENABLED),
 m_ccsEnabled(DEFAULT_CCS_ENABLED),
 m_ccsHost(DEFAULT_CCS_HOST),
+m_xlxEnabled(DEFAULT_XLX_ENABLED),
+m_xlxHostsFileUrl(DEFAULT_XLX_HOSTS_FILE_URL),
 m_starNet1Band(DEFAULT_STARNET_BAND),
 m_starNet1Callsign(DEFAULT_STARNET_CALLSIGN),
 m_starNet1Logoff(DEFAULT_STARNET_LOGOFF),
@@ -1390,6 +1402,11 @@ m_y(DEFAULT_WINDOW_Y)
 			m_ccsEnabled = temp1 == 1L;
 		} else if (key.IsSameAs(KEY_CCS_HOST)) {
 			m_ccsHost = val;
+		} else if (key.IsSameAs(KEY_XLX_ENABLED)) {
+			val.ToLong(&temp1);
+			m_xlxEnabled = temp1 == 1L;
+		} else if (key.IsSameAs(KEY_XLX_HOSTS_FILE_URL)) {
+			m_xlxHostsFileUrl = val;
 		} else if (key.IsSameAs(KEY_STARNET_BAND1)) {
 			m_starNet1Band = val;
 		} else if (key.IsSameAs(KEY_STARNET_CALLSIGN1)) {
@@ -1905,6 +1922,18 @@ void CIRCDDBGatewayConfig::setDCS(bool dcsEnabled, bool ccsEnabled, const wxStri
 	m_ccsHost    = ccsHost;
 }
 
+void CIRCDDBGatewayConfig::getXLX(bool& xlxEnabled, wxString& xlxHostsFileUrl)
+{
+	xlxEnabled = m_xlxEnabled;
+	xlxHostsFileUrl = m_xlxHostsFileUrl;
+}
+
+void CIRCDDBGatewayConfig::setXLX(bool xlxEnabled, wxString xlxHostsFileUrl)
+{
+	m_xlxEnabled = xlxEnabled;
+	m_xlxHostsFileUrl = xlxHostsFileUrl;
+}
+
 #if defined(DEXTRA_LINK) || defined(DCS_LINK)
 void CIRCDDBGatewayConfig::getStarNet1(wxString& band, wxString& callsign, wxString& logoff, wxString& info, wxString& permanent, unsigned int& userTimeout, unsigned int& groupTimeout, STARNET_CALLSIGN_SWITCH& callsignSwitch, bool& txMsgSwitch, wxString& reflector) const
 #else
@@ -2326,6 +2355,8 @@ bool CIRCDDBGatewayConfig::write()
 	m_config->Write(m_name + KEY_DCS_ENABLED, m_dcsEnabled);
 	m_config->Write(m_name + KEY_CCS_ENABLED, m_ccsEnabled);
 	m_config->Write(m_name + KEY_CCS_HOST, m_ccsHost);
+	m_config->Write(m_name + KEY_XLX_ENABLED, m_xlxEnabled);
+	m_config->Write(m_name + KEY_XLX_HOSTS_FILE_URL, m_xlxHostsFileUrl);
 	m_config->Write(m_name + KEY_STARNET_BAND1, m_starNet1Band);
 	m_config->Write(m_name + KEY_STARNET_CALLSIGN1, m_starNet1Callsign);
 	m_config->Write(m_name + KEY_STARNET_LOGOFF1, m_starNet1Logoff);
@@ -2530,6 +2561,8 @@ bool CIRCDDBGatewayConfig::write()
 	buffer.Printf(wxT("%s=%d"), KEY_DCS_ENABLED.c_str(), m_dcsEnabled ? 1 : 0); file.AddLine(buffer);
 	buffer.Printf(wxT("%s=%d"), KEY_CCS_ENABLED.c_str(), m_ccsEnabled ? 1 : 0); file.AddLine(buffer);
 	buffer.Printf(wxT("%s=%s"), KEY_CCS_HOST.c_str(), m_ccsHost.c_str()); file.AddLine(buffer);
+	buffer.Printf(wxT("%s=%d"), KEY_XLX_ENABLED.c_str(), m_xlxEnabled ? 1 : 0); file.AddLine(buffer);
+	buffer.Printf(wxT("%s=%s"), KEY_XLX_HOSTS_FILE_URL.c_str(), m_xlxHostsFileUrl.c_str()); file.AddLine(buffer);	
 	buffer.Printf(wxT("%s=%s"), KEY_STARNET_BAND1.c_str(), m_starNet1Band.c_str()); file.AddLine(buffer);
 	buffer.Printf(wxT("%s=%s"), KEY_STARNET_CALLSIGN1.c_str(), m_starNet1Callsign.c_str()); file.AddLine(buffer);
 	buffer.Printf(wxT("%s=%s"), KEY_STARNET_LOGOFF1.c_str(), m_starNet1Logoff.c_str()); file.AddLine(buffer);

--- a/ircDDBGateway/Common/IRCDDBGatewayConfig.h
+++ b/ircDDBGateway/Common/IRCDDBGatewayConfig.h
@@ -70,6 +70,9 @@ public:
 
 	void getDCS(bool& dcsEnabled, bool& ccsEnabled, wxString& ccsHost) const;
 	void setDCS(bool dcsEnabled, bool ccsEnabled, const wxString& ccsHost);
+	
+	void getXLX(bool& xlxEnabled, wxString& xlxHostsFileUrl);
+	void setXLX(bool xlxEnabled, wxString xlxHostsFileUrl);
 
 #if defined(DEXTRA_LINK) || defined(DCS_LINK)
 	void getStarNet1(wxString& band, wxString& callsign, wxString& logoff, wxString& info, wxString& permanent, unsigned int& userTimeout, unsigned int& groupTimeout, STARNET_CALLSIGN_SWITCH& callsignSwitch, bool& txMsgSwitch, wxString& reflector) const;
@@ -239,6 +242,8 @@ private:
 	bool          m_dcsEnabled;
 	bool          m_ccsEnabled;
 	wxString      m_ccsHost;
+	bool	      m_xlxEnabled;
+	wxString      m_xlxHostsFileUrl;
 	wxString      m_starNet1Band;
 	wxString      m_starNet1Callsign;
 	wxString      m_starNet1Logoff;

--- a/ircDDBGateway/GUICommon/XLXSet.cpp
+++ b/ircDDBGateway/GUICommon/XLXSet.cpp
@@ -1,0 +1,115 @@
+/*
+ *   Copyright (C) 2012,2013 by Jonathan Naylor G4KLX
+ *
+ *   This program is free software; you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation; either version 2 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program; if not, write to the Free Software
+ *   Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+
+#include "HostFile.h"
+#include "XLXSet.h"
+#include "Defs.h"
+
+#include <wx/url.h>
+
+const unsigned int CONTROL_WIDTH = 130U;
+
+const unsigned int BORDER_SIZE = 5U;
+
+const int CHOICE_ENABLED = 8788;
+
+BEGIN_EVENT_TABLE(CXLXSet, wxPanel)
+	EVT_CHOICE(CHOICE_ENABLED, CXLXSet::onEnabled)
+END_EVENT_TABLE()
+
+
+CXLXSet::CXLXSet(wxWindow* parent, int id, const wxString& title, bool xlxEnabled, const wxString& xlxHostsFileUrl) :
+wxPanel(parent, id),
+m_title(title),
+m_xlxEnabled(NULL),
+m_xlxHostsFileUrl(NULL)
+{
+	wxFlexGridSizer* sizer = new wxFlexGridSizer(2);
+
+	wxStaticText* xlxEnabledLabel = new wxStaticText(this, -1, wxT("XLX"));
+	sizer->Add(xlxEnabledLabel, 0, wxALL | wxALIGN_RIGHT, BORDER_SIZE);
+
+	m_xlxEnabled = new wxChoice(this, CHOICE_ENABLED, wxDefaultPosition, wxSize(CONTROL_WIDTH, -1));
+	m_xlxEnabled->Append(_("Disabled"));
+	m_xlxEnabled->Append(_("Enabled"));
+	sizer->Add(m_xlxEnabled, 0, wxALL | wxALIGN_LEFT, BORDER_SIZE);
+	m_xlxEnabled->SetSelection(xlxEnabled ? 1 : 0);
+
+	wxStaticText* xlxHostsFileUrlLabel = new wxStaticText(this, -1, _("Hosts file URL"));
+	sizer->Add(xlxHostsFileUrlLabel, 0, wxALL | wxALIGN_RIGHT, BORDER_SIZE);
+
+	m_xlxHostsFileUrl  = new wxTextCtrl(this, -1, xlxHostsFileUrl, wxDefaultPosition, wxSize(CONTROL_WIDTH, -1));
+	sizer->Add(m_xlxHostsFileUrl, 0, wxALL | wxALIGN_LEFT, BORDER_SIZE);
+
+
+	if (xlxEnabled)
+		m_xlxHostsFileUrl->Enable();
+	else
+		m_xlxHostsFileUrl->Disable();
+
+	SetAutoLayout(true);
+
+	SetSizer(sizer);
+}
+
+
+CXLXSet::~CXLXSet()
+{
+}
+
+bool CXLXSet::Validate()
+{
+	int n = m_xlxEnabled->GetCurrentSelection();
+	if (n == wxNOT_FOUND)
+		return false;
+
+	wxString value = m_xlxHostsFileUrl->GetValue();
+	wxURL url(value);
+	if (url.GetError() != wxURL_NOERR)
+		return false;
+
+	return true;
+}
+
+bool CXLXSet::getXLXEnabled() const
+{
+	int c = m_xlxEnabled->GetCurrentSelection();
+	if (c == wxNOT_FOUND)
+		return false;
+
+	return c == 1;
+}
+
+wxString CXLXSet::getXLXHostsFileUrl() const
+{
+	wxString value = m_xlxHostsFileUrl->GetValue();
+	wxURL url(value);
+	if (url.GetError() == wxURL_NOERR)
+		return value;
+		
+	return wxEmptyString;
+}
+
+void CXLXSet::onEnabled(wxCommandEvent &event)
+{
+	int n = m_xlxEnabled->GetCurrentSelection();
+	if (n != 1)
+		m_xlxHostsFileUrl->Disable();
+	else
+		m_xlxHostsFileUrl->Enable();
+}

--- a/ircDDBGateway/GUICommon/XLXSet.h
+++ b/ircDDBGateway/GUICommon/XLXSet.h
@@ -1,0 +1,44 @@
+/*
+ *   Copyright (C) 2012,2013 by Jonathan Naylor G4KLX
+ *
+ *   This program is free software; you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation; either version 2 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program; if not, write to the Free Software
+ *   Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+
+#ifndef	XLXSet_H
+#define	XLXSet_H
+
+#include <wx/wx.h>
+
+class CXLXSet : public wxPanel {
+public:
+	CXLXSet(wxWindow* parent, int id, const wxString& title, bool xlxEnabled, const wxString& xlxHostsFileUrl);
+	virtual ~CXLXSet();
+
+	virtual bool Validate();
+
+	virtual bool     getXLXEnabled() const;
+	virtual wxString getXLXHostsFileUrl() const;
+
+	virtual void onEnabled(wxCommandEvent& event);
+
+private:
+	wxString  m_title;
+	wxChoice* m_xlxEnabled;
+	wxTextCtrl* m_xlxHostsFileUrl;
+
+	DECLARE_EVENT_TABLE()
+};
+
+#endif

--- a/ircDDBGateway/Makefile.am
+++ b/ircDDBGateway/Makefile.am
@@ -135,7 +135,7 @@ ircddbgatewayd_SOURCES = \
 	ircDDBGateway/IRCDDBGatewayAppD.cpp \
 	ircDDBGateway/IRCDDBGatewayStatusData.cpp \
 	ircDDBGateway/IRCDDBGatewayThread.cpp
-ircddbgatewayd_LDADD = $(BASE_WX_LIBS) libCommon.a libircDDB.a
+ircddbgatewayd_LDADD = $(BASE_WX_LIBS) -lwx_baseu_net-3.0 libCommon.a libircDDB.a
 ircddbgatewayd_CPPFLAGS = -ICommon -IircDDB $(BASE_WX_CPPFLAGS)
 
 starnetserverd_SOURCES = \

--- a/ircDDBGateway/Makefile.am
+++ b/ircDDBGateway/Makefile.am
@@ -116,6 +116,7 @@ libGUICommon_a_SOURCES = \
 	GUICommon/AddressTextCtrl.cpp \
 	GUICommon/CallsignTextCtrl.cpp \
 	GUICommon/DCSSet.cpp \
+	GUICommon/XLXSet.cpp \
 	GUICommon/DescriptionTextCtrl.cpp \
 	GUICommon/DExtraSet.cpp \
 	GUICommon/DPlusSet.cpp \

--- a/ircDDBGateway/Makefile.in
+++ b/ircDDBGateway/Makefile.in
@@ -780,7 +780,7 @@ ircddbgatewayd_SOURCES = \
 	ircDDBGateway/IRCDDBGatewayStatusData.cpp \
 	ircDDBGateway/IRCDDBGatewayThread.cpp
 
-ircddbgatewayd_LDADD = $(BASE_WX_LIBS) libCommon.a libircDDB.a
+ircddbgatewayd_LDADD = $(BASE_WX_LIBS) -lwx_baseu_net-3.0 libCommon.a libircDDB.a
 ircddbgatewayd_CPPFLAGS = -ICommon -IircDDB $(BASE_WX_CPPFLAGS)
 starnetserverd_SOURCES = \
 	StarNetServer/StarNetServerAppD.cpp \

--- a/ircDDBGateway/Makefile.in
+++ b/ircDDBGateway/Makefile.in
@@ -188,6 +188,7 @@ am_libGUICommon_a_OBJECTS =  \
 	GUICommon/libGUICommon_a-AddressTextCtrl.$(OBJEXT) \
 	GUICommon/libGUICommon_a-CallsignTextCtrl.$(OBJEXT) \
 	GUICommon/libGUICommon_a-DCSSet.$(OBJEXT) \
+	GUICommon/libGUICommon_a-XLXSet.$(OBJEXT) \
 	GUICommon/libGUICommon_a-DescriptionTextCtrl.$(OBJEXT) \
 	GUICommon/libGUICommon_a-DExtraSet.$(OBJEXT) \
 	GUICommon/libGUICommon_a-DPlusSet.$(OBJEXT) \
@@ -763,6 +764,7 @@ libGUICommon_a_SOURCES = \
 	GUICommon/AddressTextCtrl.cpp \
 	GUICommon/CallsignTextCtrl.cpp \
 	GUICommon/DCSSet.cpp \
+	GUICommon/XLXSet.cpp \
 	GUICommon/DescriptionTextCtrl.cpp \
 	GUICommon/DExtraSet.cpp \
 	GUICommon/DPlusSet.cpp \
@@ -1135,6 +1137,8 @@ GUICommon/libGUICommon_a-AddressTextCtrl.$(OBJEXT):  \
 GUICommon/libGUICommon_a-CallsignTextCtrl.$(OBJEXT):  \
 	GUICommon/$(am__dirstamp) GUICommon/$(DEPDIR)/$(am__dirstamp)
 GUICommon/libGUICommon_a-DCSSet.$(OBJEXT): GUICommon/$(am__dirstamp) \
+	GUICommon/$(DEPDIR)/$(am__dirstamp)
+GUICommon/libGUICommon_a-XLXSet.$(OBJEXT): GUICommon/$(am__dirstamp) \
 	GUICommon/$(DEPDIR)/$(am__dirstamp)
 GUICommon/libGUICommon_a-DescriptionTextCtrl.$(OBJEXT):  \
 	GUICommon/$(am__dirstamp) GUICommon/$(DEPDIR)/$(am__dirstamp)
@@ -1735,6 +1739,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@GUICommon/$(DEPDIR)/libGUICommon_a-AddressTextCtrl.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@GUICommon/$(DEPDIR)/libGUICommon_a-CallsignTextCtrl.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@GUICommon/$(DEPDIR)/libGUICommon_a-DCSSet.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@GUICommon/$(DEPDIR)/libGUICommon_a-XLXSet.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@GUICommon/$(DEPDIR)/libGUICommon_a-DExtraSet.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@GUICommon/$(DEPDIR)/libGUICommon_a-DPRSSet.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@GUICommon/$(DEPDIR)/libGUICommon_a-DPlusSet.Po@am__quote@
@@ -2801,6 +2806,20 @@ GUICommon/libGUICommon_a-DCSSet.obj: GUICommon/DCSSet.cpp
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='GUICommon/DCSSet.cpp' object='GUICommon/libGUICommon_a-DCSSet.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libGUICommon_a_CPPFLAGS) $(CPPFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS) -c -o GUICommon/libGUICommon_a-DCSSet.obj `if test -f 'GUICommon/DCSSet.cpp'; then $(CYGPATH_W) 'GUICommon/DCSSet.cpp'; else $(CYGPATH_W) '$(srcdir)/GUICommon/DCSSet.cpp'; fi`
+
+GUICommon/libGUICommon_a-XLXSet.o: GUICommon/XLXSet.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libGUICommon_a_CPPFLAGS) $(CPPFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS) -MT GUICommon/libGUICommon_a-XLXSet.o -MD -MP -MF GUICommon/$(DEPDIR)/libGUICommon_a-XLXSet.Tpo -c -o GUICommon/libGUICommon_a-XLXSet.o `test -f 'GUICommon/XLXSet.cpp' || echo '$(srcdir)/'`GUICommon/XLXSet.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) GUICommon/$(DEPDIR)/libGUICommon_a-XLXSet.Tpo GUICommon/$(DEPDIR)/libGUICommon_a-XLXSet.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='GUICommon/XLXSet.cpp' object='GUICommon/libGUICommon_a-XLXSet.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libGUICommon_a_CPPFLAGS) $(CPPFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS) -c -o GUICommon/libGUICommon_a-XLXSet.o `test -f 'GUICommon/XLXSet.cpp' || echo '$(srcdir)/'`GUICommon/XLXSet.cpp
+
+GUICommon/libGUICommon_a-XLXSet.obj: GUICommon/XLXSet.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libGUICommon_a_CPPFLAGS) $(CPPFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS) -MT GUICommon/libGUICommon_a-XLXSet.obj -MD -MP -MF GUICommon/$(DEPDIR)/libGUICommon_a-XLXSet.Tpo -c -o GUICommon/libGUICommon_a-XLXSet.obj `if test -f 'GUICommon/XLXSet.cpp'; then $(CYGPATH_W) 'GUICommon/XLXSet.cpp'; else $(CYGPATH_W) '$(srcdir)/GUICommon/XLXSet.cpp'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) GUICommon/$(DEPDIR)/libGUICommon_a-XLXSet.Tpo GUICommon/$(DEPDIR)/libGUICommon_a-XLXSet.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='GUICommon/XLXSet.cpp' object='GUICommon/libGUICommon_a-XLXSet.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libGUICommon_a_CPPFLAGS) $(CPPFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS) -c -o GUICommon/libGUICommon_a-XLXSet.obj `if test -f 'GUICommon/XLXSet.cpp'; then $(CYGPATH_W) 'GUICommon/XLXSet.cpp'; else $(CYGPATH_W) '$(srcdir)/GUICommon/XLXSet.cpp'; fi`
 
 GUICommon/libGUICommon_a-DescriptionTextCtrl.o: GUICommon/DescriptionTextCtrl.cpp
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libGUICommon_a_CPPFLAGS) $(CPPFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS) -MT GUICommon/libGUICommon_a-DescriptionTextCtrl.o -MD -MP -MF GUICommon/$(DEPDIR)/libGUICommon_a-DescriptionTextCtrl.Tpo -c -o GUICommon/libGUICommon_a-DescriptionTextCtrl.o `test -f 'GUICommon/DescriptionTextCtrl.cpp' || echo '$(srcdir)/'`GUICommon/DescriptionTextCtrl.cpp

--- a/ircDDBGateway/ircDDBGateway/IRCDDBGatewayApp.cpp
+++ b/ircDDBGateway/ircDDBGateway/IRCDDBGatewayApp.cpp
@@ -834,6 +834,11 @@ void CIRCDDBGatewayApp::createThread()
 	wxString ccsHost;
 	m_config->getDCS(dcsEnabled, ccsEnabled, ccsHost);
 	wxLogInfo(wxT("DCS enabled: %d, CCS enabled: %d, server: %s"), int(dcsEnabled), int(ccsEnabled), ccsHost.c_str());
+	
+	bool xlxEnabled;
+	wxString xlxHostsFileUrl;
+	m_config->getXLX(xlxEnabled, xlxHostsFileUrl);
+	wxLogInfo(wxT("XLX enabled: %d, Hosts file url: %s"), int(xlxEnabled), xlxHostsFileUrl.c_str());
 
 	if (repeaterBand1.Len() > 1U || repeaterBand2.Len() > 1U ||
 		repeaterBand3.Len() > 1U || repeaterBand4.Len() > 1U) {
@@ -903,6 +908,7 @@ void CIRCDDBGatewayApp::createThread()
 	thread->setDExtra(dextraEnabled, dextraMaxDongles);
 	thread->setDCS(dcsEnabled);
 	thread->setCCS(ccsEnabled, ccsHost);
+	thread->setXLX(xlxEnabled, xlxHostsFileUrl);
 	thread->setInfoEnabled(infoEnabled);
 	thread->setEchoEnabled(echoEnabled);
 	thread->setDTMFEnabled(dtmfEnabled);

--- a/ircDDBGateway/ircDDBGateway/IRCDDBGatewayAppD.cpp
+++ b/ircDDBGateway/ircDDBGateway/IRCDDBGatewayAppD.cpp
@@ -823,6 +823,11 @@ bool CIRCDDBGatewayAppD::createThread()
 	wxString ccsHost;
 	config.getDCS(dcsEnabled, ccsEnabled, ccsHost);
 	wxLogInfo(wxT("DCS enabled: %d, CCS enabled: %d, server: %s"), int(dcsEnabled), int(ccsEnabled), ccsHost.c_str());
+	
+	bool xlxEnabled;
+	wxString xlxHostsFileUrl;
+	config.getXLX(xlxEnabled, xlxHostsFileUrl);
+	wxLogInfo(wxT("XLX enabled: %d, Hosts file url: %s"), int(xlxEnabled), xlxHostsFileUrl.c_str());
 
 	if (repeaterBand1.Len() > 1U || repeaterBand2.Len() > 1U ||
 		repeaterBand3.Len() > 1U || repeaterBand4.Len() > 1U) {
@@ -891,6 +896,7 @@ bool CIRCDDBGatewayAppD::createThread()
 	m_thread->setDExtra(dextraEnabled, dextraMaxDongles);
 	m_thread->setDCS(dcsEnabled);
 	m_thread->setCCS(ccsEnabled, ccsHost);
+	m_thread->setXLX(xlxEnabled, xlxHostsFileUrl);
 	m_thread->setInfoEnabled(infoEnabled);
 	m_thread->setEchoEnabled(echoEnabled);
 	m_thread->setDTMFEnabled(dtmfEnabled);

--- a/ircDDBGateway/ircDDBGateway/IRCDDBGatewayThread.cpp
+++ b/ircDDBGateway/ircDDBGateway/IRCDDBGatewayThread.cpp
@@ -1297,7 +1297,6 @@ bool CIRCDDBGatewayThread::downloadXLXReflectorList(wxString& xlxHostsFileName)
 		return false;
 	}
 	
-	wxInputStream * inputStream = url.GetInputStream();
 	wxInputStream *in = url.GetInputStream();
 
 	if(!in || !in->IsOk()) {
@@ -1308,7 +1307,13 @@ bool CIRCDDBGatewayThread::downloadXLXReflectorList(wxString& xlxHostsFileName)
 	
 	xlxHostsFileName = wxFileName::CreateTempFileName(wxT("XLX_Hosts_"));
 	wxFileOutputStream tempFileStream(xlxHostsFileName);
-	in->Read(tempFileStream);
+	if(!tempFileStream.IsOk()) {
+		wxLogError(wxT("Failed to create temporary file %s"), xlxHostsFileName);
+		delete in;
+		return false;
+	}
+		
+	tempFileStream.Write(*in);	
 	delete in;
 
 	return true;

--- a/ircDDBGateway/ircDDBGateway/IRCDDBGatewayThread.cpp
+++ b/ircDDBGateway/ircDDBGateway/IRCDDBGatewayThread.cpp
@@ -43,6 +43,9 @@
 #include <wx/filename.h>
 #include <wx/textfile.h>
 #include <wx/ffile.h>
+#include <wx/url.h>
+#include <wx/sstream.h>
+#include <wx/wfstream.h>
 
 #if defined(__WINDOWS__)
 #include "Inaddr.h"
@@ -79,6 +82,8 @@ m_dplusEnabled(false),
 m_dplusMaxDongles(0U),
 m_dplusLogin(),
 m_dcsEnabled(true),
+m_xlxEnabled(true),
+m_xlxHostsFileUrl(),
 m_ccsEnabled(true),
 m_ccsHost(),
 m_infoEnabled(true),
@@ -569,6 +574,12 @@ void CIRCDDBGatewayThread::setDPlus(bool enabled, unsigned int maxDongles, const
 void CIRCDDBGatewayThread::setDCS(bool enabled)
 {
 	m_dcsEnabled = enabled;
+}
+
+void CIRCDDBGatewayThread::setXLX(bool enabled, const wxString& xlxHostsFileUrl)
+{
+	m_xlxEnabled 	 = enabled;
+	m_xlxHostsFileUrl = xlxHostsFileUrl;
 }
 
 void CIRCDDBGatewayThread::setCCS(bool enabled, const wxString& host)
@@ -1137,6 +1148,10 @@ void CIRCDDBGatewayThread::loadReflectors()
 		if (fileName.IsFileReadable())
 			loadDCSReflectors(fileName.GetFullPath());
 	}
+
+	if(m_xlxEnabled) {
+		loadXLXReflectors();
+	}
 }
 
 void CIRCDDBGatewayThread::loadDExtraReflectors(const wxString& fileName)
@@ -1230,6 +1245,73 @@ void CIRCDDBGatewayThread::loadDCSReflectors(const wxString& fileName)
 	}
 
 	wxLogMessage(wxT("Loaded %u of %u DCS reflectors from %s"), count, hostFile.getCount(), fileName.c_str());
+}
+
+void CIRCDDBGatewayThread::loadXLXReflectors()
+{
+	wxString fileName;
+	if(!downloadXLXReflectorList(fileName)) {
+		wxLogError(wxT("Dowload of XLX hosts file failed"));
+		return;
+	}
+	
+	unsigned int count = 0U;
+
+	CHostFile hostFile(fileName, false);
+	for (unsigned int i = 0U; i < hostFile.getCount(); i++) {
+		wxString reflector = hostFile.getName(i);
+		in_addr address    = CUDPReaderWriter::lookup(hostFile.getAddress(i));
+		bool lock          = hostFile.getLock(i);
+
+		if (address.s_addr != INADDR_NONE) {
+			unsigned char* ucp = (unsigned char*)&address;
+
+			wxString addrText;
+			addrText.Printf(wxT("%u.%u.%u.%u"), ucp[0U] & 0xFFU, ucp[1U] & 0xFFU, ucp[2U] & 0xFFU, ucp[3U] & 0xFFU);
+
+			if (lock)
+				wxLogMessage(wxT("Locking %s to %s"), reflector.c_str(), addrText.c_str());
+
+			reflector.Append(wxT("        "));
+			reflector.Truncate(LONG_CALLSIGN_LENGTH - 1U);
+			reflector.Append(wxT("G"));
+
+			if(m_dcsEnabled && reflector.StartsWith(wxT("DCS")))
+				m_cache.updateGateway(reflector, addrText, DP_DCS, lock, true);
+			else if(m_dextraEnabled && reflector.StartsWith(wxT("XRF")))
+				m_cache.updateGateway(reflector, addrText, DP_DEXTRA, lock, true);
+
+			count++;
+		}
+	}
+
+	wxLogMessage(wxT("Loaded %u of %u XLX reflectors from %s"), count, hostFile.getCount(), m_xlxHostsFileUrl.c_str());
+}
+
+bool CIRCDDBGatewayThread::downloadXLXReflectorList(wxString& xlxHostsFileName)
+{
+	wxLogMessage(wxT("Downloading XLX reflector list from %s"), m_xlxHostsFileUrl.c_str());
+	wxURL url(m_xlxHostsFileUrl);
+	if(url.GetError() != wxURL_NOERR) {
+		wxLogError(wxT("Not a valid URL %s"), m_xlxHostsFileUrl.c_str());
+		return false;
+	}
+	
+	wxInputStream * inputStream = url.GetInputStream();
+	wxInputStream *in = url.GetInputStream();
+
+	if(!in || !in->IsOk()) {
+		wxLogError(wxT("Failed to download XLX reflector list"));
+		if(in) delete in;
+		return false;
+	}
+	
+	xlxHostsFileName = wxFileName::CreateTempFileName(wxT("XLX_Hosts_"));
+	wxFileOutputStream tempFileStream(xlxHostsFileName);
+	in->Read(tempFileStream);
+	delete in;
+
+	return true;
 }
 	
 void CIRCDDBGatewayThread::writeStatus()

--- a/ircDDBGateway/ircDDBGateway/IRCDDBGatewayThread.h
+++ b/ircDDBGateway/ircDDBGateway/IRCDDBGatewayThread.h
@@ -58,6 +58,7 @@ public:
 	virtual void setDExtra(bool enabled, unsigned int maxDongles);
 	virtual void setDPlus(bool enabled, unsigned int maxDongles, const wxString& login);
 	virtual void setDCS(bool enabled);
+	virtual void setXLX(bool enabled, const wxString& xlxHostFileUrl);
 	virtual void setCCS(bool enabled, const wxString& host);
 	virtual void setLog(bool enabled);
 	virtual void setAPRSWriter(CAPRSWriter* writer);
@@ -101,6 +102,8 @@ private:
 	unsigned int              m_dplusMaxDongles;
 	wxString                  m_dplusLogin;
 	bool                      m_dcsEnabled;
+	bool			  m_xlxEnabled;
+	wxString		  m_xlxHostsFileUrl;
 	bool                      m_ccsEnabled;
 	wxString                  m_ccsHost;
 	bool                      m_infoEnabled;
@@ -140,6 +143,8 @@ private:
 	void loadDExtraReflectors(const wxString& fileName);
 	void loadDPlusReflectors(const wxString& fileName);
 	void loadDCSReflectors(const wxString& fileName);
+	void loadXLXReflectors();
+	bool downloadXLXReflectorList(wxString& xlxHostsFileName);
 
 	void writeStatus();
 

--- a/ircDDBGateway/ircDDBGatewayConfig/IRCDDBGatewayConfigFrame.cpp
+++ b/ircDDBGateway/ircDDBGatewayConfig/IRCDDBGatewayConfigFrame.cpp
@@ -58,6 +58,7 @@ m_dprs(NULL),
 m_dextra(NULL),
 m_dplus(NULL),
 m_dcs(NULL),
+m_xlx(NULL),
 m_starNet1(NULL),
 m_starNet2(NULL),
 m_starNet3(NULL),
@@ -100,6 +101,10 @@ m_miscellaneous(NULL)
 	bool dcsEnabled, ccsEnabled;
 	wxString ccsHost;
 	m_config->getDCS(dcsEnabled, ccsEnabled, ccsHost);
+	
+	bool xlxEnabled;
+	wxString xlxHostsFileUrl;
+	m_config->getXLX(xlxEnabled, xlxHostsFileUrl);
 
 	GATEWAY_TYPE gatewayType;
 	wxString gatewayCallsign, gatewayAddress, icomAddress, hbAddress, description1, description2, url;
@@ -204,6 +209,9 @@ m_miscellaneous(NULL)
 
 	m_dcs = new CDCSSet(noteBook, -1, APPLICATION_NAME, dcsEnabled, ccsEnabled, ccsHost);
 	noteBook->AddPage(m_dcs, _("DCS and CCS"), false);
+	
+	m_xlx = new CXLXSet(noteBook, -1, APPLICATION_NAME, xlxEnabled, xlxHostsFileUrl);
+	noteBook->AddPage(m_xlx, _("XLX Hosts File URL"), false);
 
 #if defined(DEXTRA_LINK) || defined(DCS_LINK)
 	wxString starNetBand1, starNetCallsign1, starNetLogoff1, starNetInfo1, starNetLink1, starNetPermanent1;
@@ -360,7 +368,7 @@ void CIRCDDBGatewayConfigFrame::onSave(wxCommandEvent&)
 	if (!m_gateway->Validate() || !m_repeaterData1->Validate() || !m_repeaterInfo1->Validate() || !m_repeaterData2->Validate() ||
 		!m_repeaterInfo2->Validate() || !m_repeaterData3->Validate() || !m_repeaterInfo3->Validate() || !m_repeaterData4->Validate() ||
 		!m_repeaterInfo4->Validate() ||
-		!m_ircDDB->Validate() || !m_ircDDB2->Validate() || !m_ircDDB3->Validate() || !m_ircDDB4->Validate() || !m_dprs->Validate() || !m_dplus->Validate() || !m_dcs->Validate() ||
+		!m_ircDDB->Validate() || !m_ircDDB2->Validate() || !m_ircDDB3->Validate() || !m_ircDDB4->Validate() || !m_dprs->Validate() || !m_dplus->Validate() || !m_dcs->Validate() || !m_xlx->Validate() ||
 		!m_starNet1->Validate() || !m_starNet2->Validate() || !m_starNet3->Validate() || !m_starNet4->Validate() ||
 		!m_starNet5->Validate() || !m_remote->Validate() || !m_miscellaneous->Validate())
 		return;
@@ -505,6 +513,10 @@ void CIRCDDBGatewayConfigFrame::onSave(wxCommandEvent&)
 	bool ccsEnabled  = m_dcs->getCCSEnabled();
 	wxString ccsHost = m_dcs->getCCSHost();
 	m_config->setDCS(dcsEnabled, ccsEnabled, ccsHost);
+	
+	bool xlxEnabled  = m_xlx->getXLXEnabled();
+	wxString xlxHostsFileUrl = m_xlx->getXLXHostsFileUrl();
+	m_config->setXLX(xlxEnabled, xlxHostsFileUrl);
 
 	wxString starNetBand1             = m_starNet1->getBand();
 	wxString starNetCallsign1         = m_starNet1->getCallsign();

--- a/ircDDBGateway/ircDDBGatewayConfig/IRCDDBGatewayConfigFrame.h
+++ b/ircDDBGateway/ircDDBGatewayConfig/IRCDDBGatewayConfigFrame.h
@@ -31,6 +31,7 @@
 #include "DPlusSet.h"
 #include "DPRSSet.h"
 #include "DCSSet.h"
+#include "XLXSet.h"
 #include "Defs.h"
 
 #include <wx/wx.h>
@@ -64,6 +65,7 @@ private:
 	CDExtraSet*                           m_dextra;
 	CDPlusSet*                            m_dplus;
 	CDCSSet*                              m_dcs;
+	CXLXSet*			      m_xlx;
 	CStarNetSet*                          m_starNet1;
 	CStarNetSet*                          m_starNet2;
 	CStarNetSet*                          m_starNet3;


### PR DESCRIPTION
As a matter of fact it appears that most sysops do not update their hosts file. If they do there are dozens of different sources which do not match together. This situation leaves the repeater users unable to connect to wherever they want to (I am a true defender of the "repeaters-shall-be-able-to-connect-everywhere" principle). Thus this pull request.
The list is downloaded at startup. Only DCS and XRF are parsed. Because of to much conflicting names, DPlus are ignored.
The downloaded list has higher priority than hosts files. For the time being this is like this unless something else is required.