### PR TITLE
Fix broken ircddbGateway broken UI

### DIFF
--- a/ircDDBGateway/Common/XLXHostsFileDownloader.cpp
+++ b/ircDDBGateway/Common/XLXHostsFileDownloader.cpp
@@ -1,0 +1,86 @@
+/*
+ *   Copyright (C) 2010-2013,2015 by Jonathan Naylor G4KLX
+ *
+ *   This program is free software; you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation; either version 2 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program; if not, write to the Free Software
+ *   Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+ 
+#include "XLXHostsFileDownloader.h"
+#include <wx/protocol/http.h>
+#include <wx/filename.h>
+ 
+/* wxHTTP randomly crashes when called on a worker thread, this must be called from main thread ! */
+wxString CXLXHostsFileDownloader::Download(const wxString & xlxHostsFileURL)
+{
+	wxHTTP http;
+	http.SetNotify(false);
+	http.SetFlags(wxSOCKET_WAITALL);
+	http.SetHeader( _T("Accept") , _T("text/*") );
+	http.SetHeader( _T("User-Agent"), _T("ircddbGateway") );
+	http.SetTimeout(5); // seconds
+
+	wxLogMessage(_T("Downloading XLX reflector list from %s"), xlxHostsFileURL.c_str());
+
+	// remove "http://" from the url, i.e. minus 7 chars
+	size_t len = xlxHostsFileURL.length();
+	wxString path = xlxHostsFileURL.Right(len-7);
+	
+	// find the first forward slash
+	int slash = path.Find(wxChar('/'));
+	len = path.length();
+	wxString server = path.Left(slash);
+	path = path.Right(len-slash);
+
+	// Note that Connect() wants a host address, not an URL. 80 is the server's port.
+	if(!http.Connect(server, 80 )) {
+		wxLogError(_T("Failed to connect to %s"), server);
+		return wxEmptyString;
+	}
+	
+	wxInputStream* in = NULL;
+	if((in = http.GetInputStream(path)) && in->IsOk()) {
+		wxFile file;
+		wxString xlxHostsFileName = wxFileName::CreateTempFileName(_T("XLX_Hosts_"), &file);
+		wxLogMessage(_T("Created temporary file %s"), xlxHostsFileName);
+		if(!file.IsOpened()) {
+			wxLogError(_T("Failed to open temporary file %s"), xlxHostsFileName);
+			wxDELETE(in);
+			return wxEmptyString;
+		}
+		
+		//in->Read(fileStream);
+		//fileStream.Write(*in);
+		//in->Read(tempFileStream);
+		//Both call above seem to not work when run in a separate thread, hence the old fashion loop below
+		unsigned char buffer[2048];
+		while(!in->Eof()) {
+			in->Read(buffer, 2048);
+			int readCount = in->LastRead();
+			if(readCount <= 0)
+				break;
+
+			file.Write(buffer, readCount);
+		}
+		wxLogMessage(_T("XLX Successfuly downloaded to %s"), xlxHostsFileName);
+		file.Close();
+		http.Close();
+		wxDELETE(in);
+		return xlxHostsFileName;
+	}
+	
+	wxLogError(_T("Failed to get HTTP stream"));
+	if(in) wxDELETE(in);
+
+	return wxEmptyString;
+}

--- a/ircDDBGateway/Common/XLXHostsFileDownloader.h
+++ b/ircDDBGateway/Common/XLXHostsFileDownloader.h
@@ -1,0 +1,30 @@
+/*
+ *   Copyright (C) 2010-2013,2015 by Jonathan Naylor G4KLX
+ *
+ *   This program is free software; you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation; either version 2 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program; if not, write to the Free Software
+ *   Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+
+
+#ifndef XLXHostsFileDownloader_H
+#define XLXHostsFileDownloader_H
+
+#include <wx/wx.h>
+
+class CXLXHostsFileDownloader {
+public:
+	static wxString Download(const wxString & xlxHostsFileURL);
+};
+
+#endif

--- a/ircDDBGateway/Makefile.am
+++ b/ircDDBGateway/Makefile.am
@@ -71,6 +71,7 @@ libCommon_a_SOURCES = \
 	Common/HeaderLogger.cpp \
 	Common/HeardData.cpp \
 	Common/HostFile.cpp \
+	Common/XLXHostsFileDownloader.cpp \
 	Common/IcomRepeaterProtocolHandler.cpp \
 	Common/IRCDDBGatewayConfig.cpp \
 	Common/LogEvent.cpp \

--- a/ircDDBGateway/Makefile.in
+++ b/ircDDBGateway/Makefile.in
@@ -155,6 +155,7 @@ am_libCommon_a_OBJECTS = Common/libCommon_a-AMBEData.$(OBJEXT) \
 	Common/libCommon_a-HeaderLogger.$(OBJEXT) \
 	Common/libCommon_a-HeardData.$(OBJEXT) \
 	Common/libCommon_a-HostFile.$(OBJEXT) \
+	Common/libCommon_a-XLXHostsFileDownloader.$(OBJEXT) \
 	Common/libCommon_a-IcomRepeaterProtocolHandler.$(OBJEXT) \
 	Common/libCommon_a-IRCDDBGatewayConfig.$(OBJEXT) \
 	Common/libCommon_a-LogEvent.$(OBJEXT) \
@@ -719,6 +720,7 @@ libCommon_a_SOURCES = \
 	Common/HeaderLogger.cpp \
 	Common/HeardData.cpp \
 	Common/HostFile.cpp \
+	Common/XLXHostsFileDownloader.cpp \
 	Common/IcomRepeaterProtocolHandler.cpp \
 	Common/IRCDDBGatewayConfig.cpp \
 	Common/LogEvent.cpp \
@@ -1068,6 +1070,8 @@ Common/libCommon_a-HeaderLogger.$(OBJEXT): Common/$(am__dirstamp) \
 Common/libCommon_a-HeardData.$(OBJEXT): Common/$(am__dirstamp) \
 	Common/$(DEPDIR)/$(am__dirstamp)
 Common/libCommon_a-HostFile.$(OBJEXT): Common/$(am__dirstamp) \
+	Common/$(DEPDIR)/$(am__dirstamp)
+Common/libCommon_a-XLXHostsFileDownloader.$(OBJEXT): Common/$(am__dirstamp) \
 	Common/$(DEPDIR)/$(am__dirstamp)
 Common/libCommon_a-IcomRepeaterProtocolHandler.$(OBJEXT):  \
 	Common/$(am__dirstamp) Common/$(DEPDIR)/$(am__dirstamp)
@@ -1710,6 +1714,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@Common/$(DEPDIR)/libCommon_a-HeaderLogger.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@Common/$(DEPDIR)/libCommon_a-HeardData.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@Common/$(DEPDIR)/libCommon_a-HostFile.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@Common/$(DEPDIR)/libCommon_a-XLXHostsFileDownloader.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@Common/$(DEPDIR)/libCommon_a-IRCDDBGatewayConfig.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@Common/$(DEPDIR)/libCommon_a-IcomRepeaterProtocolHandler.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@Common/$(DEPDIR)/libCommon_a-LogEvent.Po@am__quote@
@@ -2400,6 +2405,20 @@ Common/libCommon_a-HostFile.obj: Common/HostFile.cpp
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='Common/HostFile.cpp' object='Common/libCommon_a-HostFile.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libCommon_a_CPPFLAGS) $(CPPFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS) -c -o Common/libCommon_a-HostFile.obj `if test -f 'Common/HostFile.cpp'; then $(CYGPATH_W) 'Common/HostFile.cpp'; else $(CYGPATH_W) '$(srcdir)/Common/HostFile.cpp'; fi`
+
+Common/libCommon_a-XLXHostsFileDownloader.o: Common/XLXHostsFileDownloader.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libCommon_a_CPPFLAGS) $(CPPFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS) -MT Common/libCommon_a-XLXHostsFileDownloader.o -MD -MP -MF Common/$(DEPDIR)/libCommon_a-XLXHostsFileDownloader.Tpo -c -o Common/libCommon_a-XLXHostsFileDownloader.o `test -f 'Common/XLXHostsFileDownloader.cpp' || echo '$(srcdir)/'`Common/XLXHostsFileDownloader.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) Common/$(DEPDIR)/libCommon_a-XLXHostsFileDownloader.Tpo Common/$(DEPDIR)/libCommon_a-XLXHostsFileDownloader.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='Common/XLXHostsFileDownloader.cpp' object='Common/libCommon_a-XLXHostsFileDownloader.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libCommon_a_CPPFLAGS) $(CPPFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS) -c -o Common/libCommon_a-XLXHostsFileDownloader.o `test -f 'Common/XLXHostsFileDownloader.cpp' || echo '$(srcdir)/'`Common/XLXHostsFileDownloader.cpp
+
+Common/libCommon_a-XLXHostsFileDownloader.obj: Common/XLXHostsFileDownloader.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libCommon_a_CPPFLAGS) $(CPPFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS) -MT Common/libCommon_a-XLXHostsFileDownloader.obj -MD -MP -MF Common/$(DEPDIR)/libCommon_a-XLXHostsFileDownloader.Tpo -c -o Common/libCommon_a-XLXHostsFileDownloader.obj `if test -f 'Common/XLXHostsFileDownloader.cpp'; then $(CYGPATH_W) 'Common/XLXHostsFileDownloader.cpp'; else $(CYGPATH_W) '$(srcdir)/Common/XLXHostsFileDownloader.cpp'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) Common/$(DEPDIR)/libCommon_a-XLXHostsFileDownloader.Tpo Common/$(DEPDIR)/libCommon_a-XLXHostsFileDownloader.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='Common/XLXHostsFileDownloader.cpp' object='Common/libCommon_a-XLXHostsFileDownloader.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libCommon_a_CPPFLAGS) $(CPPFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS) -c -o Common/libCommon_a-XLXHostsFileDownloader.obj `if test -f 'Common/XLXHostsFileDownloader.cpp'; then $(CYGPATH_W) 'Common/XLXHostsFileDownloader.cpp'; else $(CYGPATH_W) '$(srcdir)/Common/XLXHostsFileDownloader.cpp'; fi`
 
 Common/libCommon_a-IcomRepeaterProtocolHandler.o: Common/IcomRepeaterProtocolHandler.cpp
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libCommon_a_CPPFLAGS) $(CPPFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS) -MT Common/libCommon_a-IcomRepeaterProtocolHandler.o -MD -MP -MF Common/$(DEPDIR)/libCommon_a-IcomRepeaterProtocolHandler.Tpo -c -o Common/libCommon_a-IcomRepeaterProtocolHandler.o `test -f 'Common/IcomRepeaterProtocolHandler.cpp' || echo '$(srcdir)/'`Common/IcomRepeaterProtocolHandler.cpp

--- a/ircDDBGateway/ircDDBGateway/IRCDDBGatewayApp.cpp
+++ b/ircDDBGateway/ircDDBGateway/IRCDDBGatewayApp.cpp
@@ -30,6 +30,7 @@
 #include "IRCDDBClient.h"
 #include "IRCDDBMultiClient.h"
 #include "Utils.h"
+#include "XLXHostsFileDownloader.h"
 
 #include <wx/config.h>
 #include <wx/cmdline.h>
@@ -908,7 +909,7 @@ void CIRCDDBGatewayApp::createThread()
 	thread->setDExtra(dextraEnabled, dextraMaxDongles);
 	thread->setDCS(dcsEnabled);
 	thread->setCCS(ccsEnabled, ccsHost);
-	thread->setXLX(xlxEnabled, xlxHostsFileUrl);
+	thread->setXLX(xlxEnabled, xlxEnabled ? CXLXHostsFileDownloader::Download(xlxHostsFileUrl) : wxString(wxEmptyString));
 	thread->setInfoEnabled(infoEnabled);
 	thread->setEchoEnabled(echoEnabled);
 	thread->setDTMFEnabled(dtmfEnabled);

--- a/ircDDBGateway/ircDDBGateway/IRCDDBGatewayAppD.cpp
+++ b/ircDDBGateway/ircDDBGateway/IRCDDBGatewayAppD.cpp
@@ -30,6 +30,7 @@
 #include "IRCDDBClient.h"
 #include "IRCDDBMultiClient.h"
 #include "Utils.h"
+#include "XLXHostsFileDownloader.h"
 
 #include <wx/cmdline.h>
 #include <wx/wfstream.h>
@@ -896,7 +897,7 @@ bool CIRCDDBGatewayAppD::createThread()
 	m_thread->setDExtra(dextraEnabled, dextraMaxDongles);
 	m_thread->setDCS(dcsEnabled);
 	m_thread->setCCS(ccsEnabled, ccsHost);
-	m_thread->setXLX(xlxEnabled, xlxHostsFileUrl);
+	m_thread->setXLX(xlxEnabled, xlxEnabled ? CXLXHostsFileDownloader::Download(xlxHostsFileUrl): wxString(wxEmptyString));
 	m_thread->setInfoEnabled(infoEnabled);
 	m_thread->setEchoEnabled(echoEnabled);
 	m_thread->setDTMFEnabled(dtmfEnabled);

--- a/ircDDBGateway/ircDDBGateway/IRCDDBGatewayThread.h
+++ b/ircDDBGateway/ircDDBGateway/IRCDDBGatewayThread.h
@@ -58,7 +58,7 @@ public:
 	virtual void setDExtra(bool enabled, unsigned int maxDongles);
 	virtual void setDPlus(bool enabled, unsigned int maxDongles, const wxString& login);
 	virtual void setDCS(bool enabled);
-	virtual void setXLX(bool enabled, const wxString& xlxHostFileUrl);
+	virtual void setXLX(bool enabled, const wxString& fileName);
 	virtual void setCCS(bool enabled, const wxString& host);
 	virtual void setLog(bool enabled);
 	virtual void setAPRSWriter(CAPRSWriter* writer);
@@ -103,7 +103,7 @@ private:
 	wxString                  m_dplusLogin;
 	bool                      m_dcsEnabled;
 	bool			  m_xlxEnabled;
-	wxString		  m_xlxHostsFileUrl;
+	wxString		  m_xlxHostsFileName;
 	bool                      m_ccsEnabled;
 	wxString                  m_ccsHost;
 	bool                      m_infoEnabled;
@@ -144,7 +144,6 @@ private:
 	void loadDPlusReflectors(const wxString& fileName);
 	void loadDCSReflectors(const wxString& fileName);
 	void loadXLXReflectors();
-	bool downloadXLXReflectorList(wxString& xlxHostsFileName);
 
 	void writeStatus();
 


### PR DESCRIPTION
wxHTTP and wxURL are really flawed. They randomly crash when not called from main thread.

This commit addresses this flaw. Previous XLX implementation broke the GUI version.
DownloadLogic has been externalised to a separate class.