### PR TITLE
Temporary fix for unresolved wxHttp symbol under ubuntu, XLX priority

### DIFF
--- a/ircDDBGateway/Common/IRCDDBGatewayConfig.cpp
+++ b/ircDDBGateway/Common/IRCDDBGatewayConfig.cpp
@@ -140,6 +140,7 @@ const wxString  KEY_DCS_ENABLED          = wxT("dcsEnabled");
 const wxString  KEY_CCS_ENABLED          = wxT("ccsEnabled");
 const wxString  KEY_CCS_HOST             = wxT("ccsHost");
 const wxString  KEY_XLX_ENABLED		 = wxT("xlxEnabled");
+const wxString  KEY_XLX_OVERRIDE_LOCAL	 = wxT("xlxOverrideLocal");
 const wxString  KEY_XLX_HOSTS_FILE_URL	 = wxT("xlxHostsFileUrl");
 const wxString  KEY_STARNET_BAND1            = wxT("starNetBand1");
 const wxString  KEY_STARNET_CALLSIGN1        = wxT("starNetCallsign1");
@@ -261,7 +262,8 @@ const bool         DEFAULT_DCS_ENABLED           = true;
 const bool         DEFAULT_CCS_ENABLED           = true;
 const wxString     DEFAULT_CCS_HOST              = wxT("CCS704  ");
 const bool	   DEFAULT_XLX_ENABLED		 = true;
-const wxString	   DEFAULT_XLX_HOSTS_FILE_URL	 = wxT("http://xlxapi.rlx.lu/api.php?do=GetReflectorHostname");
+const bool	   DEFAULT_XLX_OVERRIDE_LOCAL    = true;
+const wxString	   DEFAULT_XLX_HOSTS_FILE_URL	 = _T("http://xlxapi.rlx.lu/api.php?do=GetReflectorHostname");
 const wxString     DEFAULT_STARNET_BAND          = wxEmptyString;
 const wxString     DEFAULT_STARNET_CALLSIGN      = wxEmptyString;
 const wxString     DEFAULT_STARNET_LOGOFF        = wxEmptyString;
@@ -411,6 +413,7 @@ m_dcsEnabled(DEFAULT_DCS_ENABLED),
 m_ccsEnabled(DEFAULT_CCS_ENABLED),
 m_ccsHost(DEFAULT_CCS_HOST),
 m_xlxEnabled(DEFAULT_XLX_ENABLED),
+m_xlxOverrideLocal(DEFAULT_XLX_OVERRIDE_LOCAL),
 m_xlxHostsFileUrl(DEFAULT_XLX_HOSTS_FILE_URL),
 m_starNet1Band(DEFAULT_STARNET_BAND),
 m_starNet1Callsign(DEFAULT_STARNET_CALLSIGN),
@@ -745,6 +748,8 @@ m_y(DEFAULT_WINDOW_Y)
 	
 	m_config->Read(m_name + KEY_XLX_ENABLED, &m_xlxEnabled, DEFAULT_XLX_ENABLED);
 	
+	m_config->Read(m_name + KEY_XLX_OVERRIDE_LOCAL, &m_xlxOverrideLocal, DEFAULT_XLX_OVERRIDE_LOCAL);
+	
 	m_config->Read(m_name + KEY_XLX_HOSTS_FILE_URL, &m_xlxHostsFileUrl, DEFAULT_XLX_HOSTS_FILE_URL);
 
 	m_config->Read(m_name + KEY_STARNET_BAND1, &m_starNet1Band, DEFAULT_STARNET_BAND);
@@ -1018,6 +1023,7 @@ m_dcsEnabled(DEFAULT_DCS_ENABLED),
 m_ccsEnabled(DEFAULT_CCS_ENABLED),
 m_ccsHost(DEFAULT_CCS_HOST),
 m_xlxEnabled(DEFAULT_XLX_ENABLED),
+m_xlxOverrideLocal(DEFAULT_XLX_OVERRIDE_LOCAL),
 m_xlxHostsFileUrl(DEFAULT_XLX_HOSTS_FILE_URL),
 m_starNet1Band(DEFAULT_STARNET_BAND),
 m_starNet1Callsign(DEFAULT_STARNET_CALLSIGN),
@@ -1405,6 +1411,9 @@ m_y(DEFAULT_WINDOW_Y)
 		} else if (key.IsSameAs(KEY_XLX_ENABLED)) {
 			val.ToLong(&temp1);
 			m_xlxEnabled = temp1 == 1L;
+		} else if (key.IsSameAs(KEY_XLX_OVERRIDE_LOCAL)) {
+			val.ToLong(&temp1);
+			m_xlxOverrideLocal = temp1 == 1L;
 		} else if (key.IsSameAs(KEY_XLX_HOSTS_FILE_URL)) {
 			m_xlxHostsFileUrl = val;
 		} else if (key.IsSameAs(KEY_STARNET_BAND1)) {
@@ -1922,15 +1931,17 @@ void CIRCDDBGatewayConfig::setDCS(bool dcsEnabled, bool ccsEnabled, const wxStri
 	m_ccsHost    = ccsHost;
 }
 
-void CIRCDDBGatewayConfig::getXLX(bool& xlxEnabled, wxString& xlxHostsFileUrl)
+void CIRCDDBGatewayConfig::getXLX(bool& xlxEnabled, bool& xlxOverrideLocal, wxString& xlxHostsFileUrl)
 {
 	xlxEnabled = m_xlxEnabled;
+	xlxOverrideLocal = m_xlxOverrideLocal;
 	xlxHostsFileUrl = m_xlxHostsFileUrl;
 }
 
-void CIRCDDBGatewayConfig::setXLX(bool xlxEnabled, wxString xlxHostsFileUrl)
+void CIRCDDBGatewayConfig::setXLX(bool xlxEnabled, bool xlxOverrideLocal, wxString xlxHostsFileUrl)
 {
 	m_xlxEnabled = xlxEnabled;
+	m_xlxOverrideLocal = xlxOverrideLocal;
 	m_xlxHostsFileUrl = xlxHostsFileUrl;
 }
 
@@ -2356,6 +2367,7 @@ bool CIRCDDBGatewayConfig::write()
 	m_config->Write(m_name + KEY_CCS_ENABLED, m_ccsEnabled);
 	m_config->Write(m_name + KEY_CCS_HOST, m_ccsHost);
 	m_config->Write(m_name + KEY_XLX_ENABLED, m_xlxEnabled);
+	m_config->Write(m_name + KEY_XLX_OVERRIDE_LOCAL, m_xlxOverrideLocal);
 	m_config->Write(m_name + KEY_XLX_HOSTS_FILE_URL, m_xlxHostsFileUrl);
 	m_config->Write(m_name + KEY_STARNET_BAND1, m_starNet1Band);
 	m_config->Write(m_name + KEY_STARNET_CALLSIGN1, m_starNet1Callsign);
@@ -2562,6 +2574,7 @@ bool CIRCDDBGatewayConfig::write()
 	buffer.Printf(wxT("%s=%d"), KEY_CCS_ENABLED.c_str(), m_ccsEnabled ? 1 : 0); file.AddLine(buffer);
 	buffer.Printf(wxT("%s=%s"), KEY_CCS_HOST.c_str(), m_ccsHost.c_str()); file.AddLine(buffer);
 	buffer.Printf(wxT("%s=%d"), KEY_XLX_ENABLED.c_str(), m_xlxEnabled ? 1 : 0); file.AddLine(buffer);
+	buffer.Printf(wxT("%s=%d"), KEY_XLX_OVERRIDE_LOCAL.c_str(), m_xlxOverrideLocal ? 1 : 0); file.AddLine(buffer);
 	buffer.Printf(wxT("%s=%s"), KEY_XLX_HOSTS_FILE_URL.c_str(), m_xlxHostsFileUrl.c_str()); file.AddLine(buffer);	
 	buffer.Printf(wxT("%s=%s"), KEY_STARNET_BAND1.c_str(), m_starNet1Band.c_str()); file.AddLine(buffer);
 	buffer.Printf(wxT("%s=%s"), KEY_STARNET_CALLSIGN1.c_str(), m_starNet1Callsign.c_str()); file.AddLine(buffer);

--- a/ircDDBGateway/Common/IRCDDBGatewayConfig.h
+++ b/ircDDBGateway/Common/IRCDDBGatewayConfig.h
@@ -71,8 +71,8 @@ public:
 	void getDCS(bool& dcsEnabled, bool& ccsEnabled, wxString& ccsHost) const;
 	void setDCS(bool dcsEnabled, bool ccsEnabled, const wxString& ccsHost);
 	
-	void getXLX(bool& xlxEnabled, wxString& xlxHostsFileUrl);
-	void setXLX(bool xlxEnabled, wxString xlxHostsFileUrl);
+	void getXLX(bool& xlxEnabled, bool& xlxOverrideLocal, wxString& xlxHostsFileUrl);
+	void setXLX(bool xlxEnabled, bool xlxOverrideLocal, wxString xlxHostsFileUrl);
 
 #if defined(DEXTRA_LINK) || defined(DCS_LINK)
 	void getStarNet1(wxString& band, wxString& callsign, wxString& logoff, wxString& info, wxString& permanent, unsigned int& userTimeout, unsigned int& groupTimeout, STARNET_CALLSIGN_SWITCH& callsignSwitch, bool& txMsgSwitch, wxString& reflector) const;
@@ -243,6 +243,7 @@ private:
 	bool          m_ccsEnabled;
 	wxString      m_ccsHost;
 	bool	      m_xlxEnabled;
+	bool	      m_xlxOverrideLocal;
 	wxString      m_xlxHostsFileUrl;
 	wxString      m_starNet1Band;
 	wxString      m_starNet1Callsign;

--- a/ircDDBGateway/Common/XLXHostsFileDownloader.cpp
+++ b/ircDDBGateway/Common/XLXHostsFileDownloader.cpp
@@ -17,12 +17,28 @@
  */
  
 #include "XLXHostsFileDownloader.h"
+#ifdef XLX_USE_WGET
+#include <wx/utils.h> 
+#else
 #include <wx/protocol/http.h>
+#endif
 #include <wx/filename.h>
  
 /* wxHTTP randomly crashes when called on a worker thread, this must be called from main thread ! */
 wxString CXLXHostsFileDownloader::Download(const wxString & xlxHostsFileURL)
 {
+#ifdef XLX_USE_WGET
+	wxString xlxHostsFileName = wxFileName::CreateTempFileName(_T("XLX_Hosts_"));
+	wxString commandLine = _T("wget -q -O ") + xlxHostsFileName + _T(" ") + xlxHostsFileURL;
+	bool execResult = wxShell(commandLine);
+	
+	if(!execResult) {
+		wxLogError(_T("Unable do download XLX host file, make sure wget is installed"));
+		return wxEmptyString;
+	}
+	
+	return xlxHostsFileName;
+#else
 	wxHTTP http;
 	http.SetNotify(false);
 	http.SetFlags(wxSOCKET_WAITALL);
@@ -83,4 +99,5 @@ wxString CXLXHostsFileDownloader::Download(const wxString & xlxHostsFileURL)
 	if(in) wxDELETE(in);
 
 	return wxEmptyString;
+#endif
 }

--- a/ircDDBGateway/Common/XLXHostsFileDownloader.h
+++ b/ircDDBGateway/Common/XLXHostsFileDownloader.h
@@ -19,7 +19,7 @@
 
 #ifndef XLXHostsFileDownloader_H
 #define XLXHostsFileDownloader_H
-
+#define XLX_USE_WGET
 #include <wx/wx.h>
 
 class CXLXHostsFileDownloader {

--- a/ircDDBGateway/GUICommon/XLXSet.cpp
+++ b/ircDDBGateway/GUICommon/XLXSet.cpp
@@ -20,7 +20,8 @@
 #include "XLXSet.h"
 #include "Defs.h"
 
-#include <wx/url.h>
+// TODO F4FXL try to figure out why below symbols are not found under ubuntu
+//#include <wx/url.h>
 
 const unsigned int CONTROL_WIDTH = 130U;
 
@@ -87,11 +88,16 @@ bool CXLXSet::Validate()
 	int n = m_xlxEnabled->GetCurrentSelection();
 	if (n == wxNOT_FOUND)
 		return false;
+		
+	int n = m_xlxOverrideLocal->GetCurrentSelection();
+	if (n == wxNOT_FOUND)
+		return false;
 
-	wxString value = m_xlxHostsFileUrl->GetValue();
+	// TODO F4FXL try to figure out why below symbols are not found under ubuntu
+	/*wxString value = m_xlxHostsFileUrl->GetValue();
 	wxURL url(value);
 	if (url.GetError() != wxURL_NOERR)
-		return false;
+		return false;*/
 
 	return true;
 }

--- a/ircDDBGateway/GUICommon/XLXSet.cpp
+++ b/ircDDBGateway/GUICommon/XLXSet.cpp
@@ -89,7 +89,7 @@ bool CXLXSet::Validate()
 	if (n == wxNOT_FOUND)
 		return false;
 		
-	int n = m_xlxOverrideLocal->GetCurrentSelection();
+	n = m_xlxOverrideLocal->GetCurrentSelection();
 	if (n == wxNOT_FOUND)
 		return false;
 
@@ -123,9 +123,12 @@ bool CXLXSet::getXLXEnabled() const
 wxString CXLXSet::getXLXHostsFileUrl() const
 {
 	wxString value = m_xlxHostsFileUrl->GetValue();
-	wxURL url(value);
-	if (url.GetError() == wxURL_NOERR)
-		return value;
+	
+	
+	// TODO F4FXL try to figure out why below symbols are not found under ubuntu
+	//wxURL url(value);
+	//if (url.GetError() == wxURL_NOERR)
+	//	return value;
 		
 	return wxEmptyString;
 }

--- a/ircDDBGateway/GUICommon/XLXSet.cpp
+++ b/ircDDBGateway/GUICommon/XLXSet.cpp
@@ -33,10 +33,11 @@ BEGIN_EVENT_TABLE(CXLXSet, wxPanel)
 END_EVENT_TABLE()
 
 
-CXLXSet::CXLXSet(wxWindow* parent, int id, const wxString& title, bool xlxEnabled, const wxString& xlxHostsFileUrl) :
+CXLXSet::CXLXSet(wxWindow* parent, int id, const wxString& title, bool xlxEnabled, bool xlxOverrideLocal, const wxString& xlxHostsFileUrl) :
 wxPanel(parent, id),
 m_title(title),
 m_xlxEnabled(NULL),
+m_xlxOverrideLocal(NULL),
 m_xlxHostsFileUrl(NULL)
 {
 	wxFlexGridSizer* sizer = new wxFlexGridSizer(2);
@@ -49,6 +50,15 @@ m_xlxHostsFileUrl(NULL)
 	m_xlxEnabled->Append(_("Enabled"));
 	sizer->Add(m_xlxEnabled, 0, wxALL | wxALIGN_LEFT, BORDER_SIZE);
 	m_xlxEnabled->SetSelection(xlxEnabled ? 1 : 0);
+	
+	wxStaticText* xlxOverrideLocalLabel = new wxStaticText(this, -1, _("Override local hosts files"));
+	sizer->Add(xlxOverrideLocalLabel, 0, wxALL | wxALIGN_RIGHT, BORDER_SIZE);
+	
+	m_xlxOverrideLocal = new wxChoice(this, CHOICE_ENABLED, wxDefaultPosition, wxSize(CONTROL_WIDTH, -1));
+	m_xlxOverrideLocal->Append(_("No"));
+	m_xlxOverrideLocal->Append(_("Yes"));
+	sizer->Add(m_xlxOverrideLocal, 0, wxALL | wxALIGN_LEFT, BORDER_SIZE);
+	m_xlxOverrideLocal->SetSelection(xlxOverrideLocal ? 1 : 0);
 
 	wxStaticText* xlxHostsFileUrlLabel = new wxStaticText(this, -1, _("Hosts file URL"));
 	sizer->Add(xlxHostsFileUrlLabel, 0, wxALL | wxALIGN_RIGHT, BORDER_SIZE);
@@ -84,6 +94,15 @@ bool CXLXSet::Validate()
 		return false;
 
 	return true;
+}
+
+bool CXLXSet::getXLXOverrideLocal() const
+{
+	int c = m_xlxEnabled->GetCurrentSelection();
+	if (c == wxNOT_FOUND)
+		return false;
+
+	return c == 1;
 }
 
 bool CXLXSet::getXLXEnabled() const

--- a/ircDDBGateway/GUICommon/XLXSet.h
+++ b/ircDDBGateway/GUICommon/XLXSet.h
@@ -23,12 +23,13 @@
 
 class CXLXSet : public wxPanel {
 public:
-	CXLXSet(wxWindow* parent, int id, const wxString& title, bool xlxEnabled, const wxString& xlxHostsFileUrl);
+	CXLXSet(wxWindow* parent, int id, const wxString& title, bool xlxEnabled, bool xlxOverrideLocal, const wxString& xlxHostsFileUrl);
 	virtual ~CXLXSet();
 
 	virtual bool Validate();
 
 	virtual bool     getXLXEnabled() const;
+	virtual bool     getXLXOverrideLocal() const;
 	virtual wxString getXLXHostsFileUrl() const;
 
 	virtual void onEnabled(wxCommandEvent& event);
@@ -36,6 +37,7 @@ public:
 private:
 	wxString  m_title;
 	wxChoice* m_xlxEnabled;
+	wxChoice* m_xlxOverrideLocal;
 	wxTextCtrl* m_xlxHostsFileUrl;
 
 	DECLARE_EVENT_TABLE()

--- a/ircDDBGateway/ircDDBGateway/IRCDDBGatewayApp.cpp
+++ b/ircDDBGateway/ircDDBGateway/IRCDDBGatewayApp.cpp
@@ -837,9 +837,10 @@ void CIRCDDBGatewayApp::createThread()
 	wxLogInfo(wxT("DCS enabled: %d, CCS enabled: %d, server: %s"), int(dcsEnabled), int(ccsEnabled), ccsHost.c_str());
 	
 	bool xlxEnabled;
+	bool xlxOverrideLocal;
 	wxString xlxHostsFileUrl;
-	m_config->getXLX(xlxEnabled, xlxHostsFileUrl);
-	wxLogInfo(wxT("XLX enabled: %d, Hosts file url: %s"), int(xlxEnabled), xlxHostsFileUrl.c_str());
+	m_config->getXLX(xlxEnabled, xlxOverrideLocal, xlxHostsFileUrl);
+	wxLogInfo(wxT("XLX enabled: %d, Override Local %d, Hosts file url: %s"), int(xlxEnabled), int(xlxOverrideLocal), xlxHostsFileUrl.c_str());
 
 	if (repeaterBand1.Len() > 1U || repeaterBand2.Len() > 1U ||
 		repeaterBand3.Len() > 1U || repeaterBand4.Len() > 1U) {
@@ -909,7 +910,7 @@ void CIRCDDBGatewayApp::createThread()
 	thread->setDExtra(dextraEnabled, dextraMaxDongles);
 	thread->setDCS(dcsEnabled);
 	thread->setCCS(ccsEnabled, ccsHost);
-	thread->setXLX(xlxEnabled, xlxEnabled ? CXLXHostsFileDownloader::Download(xlxHostsFileUrl) : wxString(wxEmptyString));
+	thread->setXLX(xlxEnabled, xlxOverrideLocal, xlxEnabled ? CXLXHostsFileDownloader::Download(xlxHostsFileUrl) : wxString(wxEmptyString));
 	thread->setInfoEnabled(infoEnabled);
 	thread->setEchoEnabled(echoEnabled);
 	thread->setDTMFEnabled(dtmfEnabled);

--- a/ircDDBGateway/ircDDBGateway/IRCDDBGatewayAppD.cpp
+++ b/ircDDBGateway/ircDDBGateway/IRCDDBGatewayAppD.cpp
@@ -826,9 +826,10 @@ bool CIRCDDBGatewayAppD::createThread()
 	wxLogInfo(wxT("DCS enabled: %d, CCS enabled: %d, server: %s"), int(dcsEnabled), int(ccsEnabled), ccsHost.c_str());
 	
 	bool xlxEnabled;
+	bool xlxOverrideLocal;
 	wxString xlxHostsFileUrl;
-	config.getXLX(xlxEnabled, xlxHostsFileUrl);
-	wxLogInfo(wxT("XLX enabled: %d, Hosts file url: %s"), int(xlxEnabled), xlxHostsFileUrl.c_str());
+	config.getXLX(xlxEnabled, xlxOverrideLocal, xlxHostsFileUrl);
+	wxLogInfo(wxT("XLX enabled: %d, Override Local %d, Hosts file url: %s"), int(xlxEnabled), int(xlxOverrideLocal), xlxHostsFileUrl.c_str());
 
 	if (repeaterBand1.Len() > 1U || repeaterBand2.Len() > 1U ||
 		repeaterBand3.Len() > 1U || repeaterBand4.Len() > 1U) {
@@ -897,7 +898,7 @@ bool CIRCDDBGatewayAppD::createThread()
 	m_thread->setDExtra(dextraEnabled, dextraMaxDongles);
 	m_thread->setDCS(dcsEnabled);
 	m_thread->setCCS(ccsEnabled, ccsHost);
-	m_thread->setXLX(xlxEnabled, xlxEnabled ? CXLXHostsFileDownloader::Download(xlxHostsFileUrl): wxString(wxEmptyString));
+	m_thread->setXLX(xlxEnabled, xlxOverrideLocal, xlxEnabled ? CXLXHostsFileDownloader::Download(xlxHostsFileUrl): wxString(wxEmptyString));
 	m_thread->setInfoEnabled(infoEnabled);
 	m_thread->setEchoEnabled(echoEnabled);
 	m_thread->setDTMFEnabled(dtmfEnabled);

--- a/ircDDBGateway/ircDDBGateway/IRCDDBGatewayThread.cpp
+++ b/ircDDBGateway/ircDDBGateway/IRCDDBGatewayThread.cpp
@@ -576,10 +576,11 @@ void CIRCDDBGatewayThread::setDCS(bool enabled)
 	m_dcsEnabled = enabled;
 }
 
-void CIRCDDBGatewayThread::setXLX(bool enabled, const wxString& xlxHostsFileName)
+void CIRCDDBGatewayThread::setXLX(bool enabled, bool overrideLocal, const wxString& xlxHostsFileName)
 {
 	m_xlxEnabled 	 = enabled;
 	m_xlxHostsFileName = xlxHostsFileName;
+	m_xlxOverrideLocal = overrideLocal;
 }
 
 void CIRCDDBGatewayThread::setCCS(bool enabled, const wxString& host)
@@ -1107,6 +1108,10 @@ void CIRCDDBGatewayThread::loadGateways()
 
 void CIRCDDBGatewayThread::loadReflectors()
 {
+	if(m_xlxEnabled && !m_xlxOverrideLocal) {
+		loadXLXReflectors();
+	}
+	
 	if (m_dplusEnabled) {
 		wxFileName fileName(wxFileName::GetHomeDir(), DPLUS_HOSTS_FILE_NAME);
 		if (fileName.IsFileReadable())
@@ -1149,7 +1154,7 @@ void CIRCDDBGatewayThread::loadReflectors()
 			loadDCSReflectors(fileName.GetFullPath());
 	}
 
-	if(m_xlxEnabled) {
+	if(m_xlxEnabled && m_xlxOverrideLocal) {
 		loadXLXReflectors();
 	}
 }

--- a/ircDDBGateway/ircDDBGateway/IRCDDBGatewayThread.h
+++ b/ircDDBGateway/ircDDBGateway/IRCDDBGatewayThread.h
@@ -58,7 +58,7 @@ public:
 	virtual void setDExtra(bool enabled, unsigned int maxDongles);
 	virtual void setDPlus(bool enabled, unsigned int maxDongles, const wxString& login);
 	virtual void setDCS(bool enabled);
-	virtual void setXLX(bool enabled, const wxString& fileName);
+	virtual void setXLX(bool enabled, bool overrideLocal, const wxString& fileName);
 	virtual void setCCS(bool enabled, const wxString& host);
 	virtual void setLog(bool enabled);
 	virtual void setAPRSWriter(CAPRSWriter* writer);
@@ -103,6 +103,7 @@ private:
 	wxString                  m_dplusLogin;
 	bool                      m_dcsEnabled;
 	bool			  m_xlxEnabled;
+	bool			  m_xlxOverrideLocal;
 	wxString		  m_xlxHostsFileName;
 	bool                      m_ccsEnabled;
 	wxString                  m_ccsHost;

--- a/ircDDBGateway/ircDDBGatewayConfig/IRCDDBGatewayConfigFrame.cpp
+++ b/ircDDBGateway/ircDDBGatewayConfig/IRCDDBGatewayConfigFrame.cpp
@@ -103,8 +103,9 @@ m_miscellaneous(NULL)
 	m_config->getDCS(dcsEnabled, ccsEnabled, ccsHost);
 	
 	bool xlxEnabled;
+	bool xlxOverrideLocal;
 	wxString xlxHostsFileUrl;
-	m_config->getXLX(xlxEnabled, xlxHostsFileUrl);
+	m_config->getXLX(xlxEnabled, xlxOverrideLocal, xlxHostsFileUrl);
 
 	GATEWAY_TYPE gatewayType;
 	wxString gatewayCallsign, gatewayAddress, icomAddress, hbAddress, description1, description2, url;
@@ -210,8 +211,8 @@ m_miscellaneous(NULL)
 	m_dcs = new CDCSSet(noteBook, -1, APPLICATION_NAME, dcsEnabled, ccsEnabled, ccsHost);
 	noteBook->AddPage(m_dcs, _("DCS and CCS"), false);
 	
-	m_xlx = new CXLXSet(noteBook, -1, APPLICATION_NAME, xlxEnabled, xlxHostsFileUrl);
-	noteBook->AddPage(m_xlx, _("XLX Hosts File URL"), false);
+	m_xlx = new CXLXSet(noteBook, -1, APPLICATION_NAME, xlxEnabled, xlxOverrideLocal, xlxHostsFileUrl);
+	noteBook->AddPage(m_xlx, _("XLX Hosts File"), false);
 
 #if defined(DEXTRA_LINK) || defined(DCS_LINK)
 	wxString starNetBand1, starNetCallsign1, starNetLogoff1, starNetInfo1, starNetLink1, starNetPermanent1;
@@ -515,8 +516,9 @@ void CIRCDDBGatewayConfigFrame::onSave(wxCommandEvent&)
 	m_config->setDCS(dcsEnabled, ccsEnabled, ccsHost);
 	
 	bool xlxEnabled  = m_xlx->getXLXEnabled();
+	bool xlxOverrideLocal = m_xlx->getXLXOverrideLocal();
 	wxString xlxHostsFileUrl = m_xlx->getXLXHostsFileUrl();
-	m_config->setXLX(xlxEnabled, xlxHostsFileUrl);
+	m_config->setXLX(xlxEnabled, xlxOverrideLocal, xlxHostsFileUrl);
 
 	wxString starNetBand1             = m_starNet1->getBand();
 	wxString starNetCallsign1         = m_starNet1->getCallsign();


### PR DESCRIPTION
This uses wget to download the XLX host file. Not best solution, but at
least more universal.
This should solve https://github.com/dl5di/OpenDV/issues/119 until better solution is found

This also adds the ability for XLX to override the content of local hosts
file or not.
new in config file xlxOverrideLocal
Default is to override local files.