### PR TITLE
Fix typos.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,25 +14,24 @@ https://github.com/dl5di/OpenDV/wiki/ircDDB-Gateway-Installation
     make
     sudo make install
 
-./configure can be ran with optional flags, see OpenDV wiki for further details
+./configure can be run with optional flags, see the OpenDV wiki for further details
 
-    --with-gpio to enable wiringPi on the RPi.
-    --without-gui no GUI build eliminating WX-GUI
+    --with-gpio          to enable wiringPi on the RPi.
+    --without-gui        no GUI build eliminating WX-GUI
 
-Spicific to DStarRepeater and DummyRepeater
+Specific to DStarRepeater and DummyRepeater
 
     --with-stardv        flag to compile the Star*DV adapter in the STARDV directory
-    --with-ambeserver        flag that compiles AMBEserver in the DV3000 directory.
+    --with-ambeserver    flag that compiles AMBEserver in the DV3000 directory.
 
 
 ##Support
-```
-pre-compiled binary files are located in the Yahoo! groups including windows binary files.
 
-please see the Yahoo! users group email reflectors. for peer-support.
-ircDDB Yahoo! group, pcrepeatercontroller Yahoo! group, and the mmdvm Yahoo! group.
+Pre-compiled binary files are located in the Yahoo! groups including Windows binary files.
 
-https://groups.yahoo.com/neo/groups/ircDDBGateway/info
-https://groups.yahoo.com/neo/groups/pcrepeatercontroller/info
-https://groups.yahoo.com/neo/groups/mmdvm/info
-```
+Please see the Yahoo! users group email reflectors for peer-support.
+
+* [ircDDB Yahoo! group](https://groups.yahoo.com/neo/groups/ircDDBGateway/info)
+* [PC Repeater Controller Yahoo! group](https://groups.yahoo.com/neo/groups/pcrepeatercontroller/info)
+* [MMDVM Yahoo! group](https://groups.yahoo.com/neo/groups/mmdvm/info)
+


### PR DESCRIPTION
Also use Markdown link format to avoid preformatted text block.