### PR TITLE
Make PID writing and stopping via init.d/systemd work

### DIFF
--- a/LinuxExtras/Debian/ircDDBGateway/etc/init.d/ircddbgateway
+++ b/LinuxExtras/Debian/ircDDBGateway/etc/init.d/ircddbgateway
@@ -124,7 +124,7 @@ do_stop()
     	    sleep 15
 	fi                    
 
-	start-stop-daemon --stop --quiet --retry=TERM/30/KILL/5 --pidfile $PIDFILE --name $NAME
+	start-stop-daemon --stop --quiet --retry=TERM/30/KILL/5 --pidfile $PIDFILE --name $DAEMON_NAME
 	RETVAL="$?"
 	[ "$RETVAL" = 2 ] && return 2
 
@@ -153,7 +153,7 @@ do_reload() {
 	# restarting (for example, when it is sent a SIGHUP),
 	# then implement that here.
 	#
-	start-stop-daemon --stop --signal 1 --quiet --pidfile $PIDFILE --name $NAME
+	start-stop-daemon --stop --signal 1 --quiet --pidfile $PIDFILE --name $DAEMON_NAME
 	return 0
 }
 

--- a/LinuxExtras/Debian/ircDDBGateway/etc/init.d/ircddbgateway
+++ b/LinuxExtras/Debian/ircDDBGateway/etc/init.d/ircddbgateway
@@ -57,12 +57,18 @@ do_start()
 	#   1 if daemon was already running
 	#   2 if daemon could not be started
 
-	# Check if the PID file exists and the actual status of the process
-	if [ -e $PIDFILE ]; then
-		status_of_proc -p $PIDFILE $DAEMON_PATH "$NAME process" && status="0" || status="$?"
-		# If the status is SUCCESS then don't need to start again.
-		if [ $status = "0" ]; then
-			return 1 # Exit
+	# Check if the PID directory and file exists and the actual status of the process
+	PIDDIR=$(dirname "$PIDFILE")
+	if [ ! -d "$PIDDIR" ]; then
+		mkdir $PIDDIR
+		chown $DAEMON_USER $PIDDIR
+	else
+		if [ -e $PIDFILE ]; then
+			status_of_proc -p $PIDFILE $DAEMON_PATH "$NAME process" && status="0" || status="$?"
+			# If the status is SUCCESS then don't need to start again.
+			if [ $status = "0" ]; then
+				return 1 # Exit
+			fi
 		fi
 	fi
  

--- a/LinuxExtras/Raspbian/ircDDBGateway/etc/init.d/ircddbgateway
+++ b/LinuxExtras/Raspbian/ircDDBGateway/etc/init.d/ircddbgateway
@@ -124,7 +124,7 @@ do_stop()
     	    sleep 15
 	fi                    
 
-	start-stop-daemon --stop --quiet --retry=TERM/30/KILL/5 --pidfile $PIDFILE --name $NAME
+	start-stop-daemon --stop --quiet --retry=TERM/30/KILL/5 --pidfile $PIDFILE --name $DAEMON_NAME
 	RETVAL="$?"
 	[ "$RETVAL" = 2 ] && return 2
 	
@@ -153,7 +153,7 @@ do_reload() {
 	# restarting (for example, when it is sent a SIGHUP),
 	# then implement that here.
 	#
-	start-stop-daemon --stop --signal 1 --quiet --pidfile $PIDFILE --name $NAME
+	start-stop-daemon --stop --signal 1 --quiet --pidfile $PIDFILE --name $DAEMON_NAME
 	return 0
 }
 

--- a/LinuxExtras/Raspbian/ircDDBGateway/etc/init.d/ircddbgateway
+++ b/LinuxExtras/Raspbian/ircDDBGateway/etc/init.d/ircddbgateway
@@ -57,12 +57,18 @@ do_start()
 	#   1 if daemon was already running
 	#   2 if daemon could not be started
 
-	# Check if the PID file exists and the actual status of the process
-	if [ -e $PIDFILE ]; then
-		status_of_proc -p $PIDFILE $DAEMON_PATH "$NAME process" && status="0" || status="$?"
-		# If the status is SUCCESS then don't need to start again.
-		if [ $status = "0" ]; then
-			return 1 # Exit
+	# Check if the PID directory and file exists and the actual status of the process
+	PIDDIR=$(dirname "$PIDFILE")
+	if [ ! -d "$PIDDIR" ]; then
+		mkdir $PIDDIR
+		chown $DAEMON_USER $PIDDIR
+	else
+		if [ -e $PIDFILE ]; then
+			status_of_proc -p $PIDFILE $DAEMON_PATH "$NAME process" && status="0" || status="$?"
+			# If the status is SUCCESS then don't need to start again.
+			if [ $status = "0" ]; then
+				return 1 # Exit
+			fi
 		fi
 	fi
 

--- a/ircDDBGateway/ircDDBGateway/IRCDDBGatewayAppD.cpp
+++ b/ircDDBGateway/ircDDBGateway/IRCDDBGatewayAppD.cpp
@@ -119,9 +119,9 @@ int main(int argc, char** argv)
 
 	wxString pidFileName;
 	if (!name.IsEmpty())
-		pidFileName.Printf(wxT("/var/run/ircddbgateway_%s.pid"), name.c_str());
+		pidFileName.Printf(wxT("/var/run/opendv/ircddbgateway_%s.pid"), name.c_str());
 	else
-		pidFileName = wxT("/var/run/ircddbgateway.pid");
+		pidFileName = wxT("/var/run/opendv/ircddbgateway.pid");
 	pidFileName.Replace(wxT(" "), wxT("_"));
 
 	char fileName[128U];


### PR DESCRIPTION
The code has two issues:
- The path for the PID file in the ircddgatewayd differs from what the init.d/systemd script expects (/var/run/opendv vs. /var/run)
- Writing the PID fails because the ircddbgatewayd binary runs under user opendv who does not have rights to write to /var/run normally

This PR fixes both.