### PR TITLE
G2 Udp hole punching / NAT Traversal

### DIFF
--- a/ircDDBGateway/Common/G2ProtocolHandler.cpp
+++ b/ircDDBGateway/Common/G2ProtocolHandler.cpp
@@ -147,13 +147,13 @@ CAMBEData* CG2ProtocolHandler::readAMBE()
 void CG2ProtocolHandler::PunchUDPHole(const wxString& address)
 {
 	unsigned char buffer[1];
-	buffer[0] = 0;
+	::memset(buffer, 0, 1);
 	
-	in_addr addr;
-	addr.s_addr = ::inet_addr(address.mb_str());
+	in_addr addr = CUDPReaderWriter::lookup(address);
 
-	for(int i = 0; i < 3; i++)
-		m_socket.write(buffer, 1, addr, m_port);
+	//wxLogError(wxT("Punching hole to %s"), address.mb_str());
+
+	m_socket.write(buffer, 1, addr, G2_DV_PORT);
 }
 
 void CG2ProtocolHandler::close()

--- a/ircDDBGateway/Common/G2ProtocolHandler.cpp
+++ b/ircDDBGateway/Common/G2ProtocolHandler.cpp
@@ -144,6 +144,18 @@ CAMBEData* CG2ProtocolHandler::readAMBE()
 	return data;
 }
 
+void CG2ProtocolHandler::PunchUDPHole(const wxString& address)
+{
+	unsigned char buffer[1];
+	buffer[0] = 0;
+	
+	in_addr addr;
+	addr.s_addr = ::inet_addr(address.mb_str());
+
+	for(int i = 0; i < 3; i++)
+		m_socket.write(buffer, 1, addr, m_port);
+}
+
 void CG2ProtocolHandler::close()
 {
 	m_socket.close();

--- a/ircDDBGateway/Common/G2ProtocolHandler.h
+++ b/ircDDBGateway/Common/G2ProtocolHandler.h
@@ -52,6 +52,8 @@ public:
 	CHeaderData* readHeader();
 	CAMBEData*   readAMBE();
 
+	void PunchUDPHole(const wxString& addr);
+
 	void close();
 
 private:

--- a/ircDDBGateway/ircDDBGateway/IRCDDBGatewayThread.cpp
+++ b/ircDDBGateway/ircDDBGateway/IRCDDBGatewayThread.cpp
@@ -728,6 +728,7 @@ void CIRCDDBGatewayThread::processIrcDDB()
 					if (!address.IsEmpty()) {
 						wxLogMessage(wxT("USER: %s %s %s %s"), user.c_str(), repeater.c_str(), gateway.c_str(), address.c_str());
 						m_cache.updateUser(user, repeater, gateway, address, timestamp, DP_DEXTRA, false, false);
+						m_g2Handler->PunchUDPHole(address);
 					} else {
 						wxLogMessage(wxT("USER: %s NOT FOUND"), user.c_str());
 					}
@@ -744,6 +745,7 @@ void CIRCDDBGatewayThread::processIrcDDB()
 					if (!address.IsEmpty()) {
 						wxLogMessage(wxT("REPEATER: %s %s %s"), repeater.c_str(), gateway.c_str(), address.c_str());
 						m_cache.updateRepeater(repeater, gateway, address, DP_DEXTRA, false, false);
+						m_g2Handler->PunchUDPHole(address);
 					} else {
 						wxLogMessage(wxT("REPEATER: %s NOT FOUND"), repeater.c_str());
 					}
@@ -761,6 +763,7 @@ void CIRCDDBGatewayThread::processIrcDDB()
 					if (!address.IsEmpty()) {
 						wxLogMessage(wxT("GATEWAY: %s %s"), gateway.c_str(), address.c_str());
 						m_cache.updateGateway(gateway, address, DP_DEXTRA, false, false);
+						m_g2Handler->PunchUDPHole(address);
 					} else {
 						wxLogMessage(wxT("GATEWAY: %s NOT FOUND"), gateway.c_str());
 					}


### PR DESCRIPTION
Hi,

This adds a simple UDP Hole punching/NAT Traversal mechanism to enable G2 (Call Sign Routing) for gateways running with non public IP, typically mobile networks.

I have recently read about UDP hole punching / NAT Traversal which is used in kademlia protocol. I decided to go for it and to see if it is possible to implement it to allow G2 to traverse NAT routers.

This turned out to be quite easy yet it has one limitation. There can only be one gateway behind the NAT router.

This works by sending a dummy 1 byte UDP packet on the G2 port every time a gateway is seen on the ircddb network. In case both gateway want to talk together the hole is already punched for DV data to flow through, if gateways don't NAT router will kill the UDP session after TTL is expired.

73
Geoffrey F4FXL - KC3FRA